### PR TITLE
feat: 스키마 제약 조건, 열거형, Org 소유권 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,388 @@
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
+// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
+
+generator client {
+  provider = "prisma-client"
+  output   = "../lib/generated/prisma"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+enum AppRole {
+  candidate
+  recruiter
+  admin
+
+  @@map("app_role")
+}
+
+enum EmploymentType {
+  full_time
+  part_time
+  intern
+  freelance
+
+  @@map("employment_type")
+}
+
+enum WorkArrangement {
+  onsite
+  hybrid
+  remote
+
+  @@map("work_arrangement")
+}
+
+enum LanguageProficiency {
+  native
+  fluent
+  professional
+  basic
+
+  @@map("language_proficiency")
+}
+
+enum EducationTypeVn {
+  vet_elementary
+  vet_intermediate
+  vet_college
+  higher_bachelor
+  higher_master
+  higher_doctorate
+  continuing_education
+  international_program
+  other
+
+  @@map("education_type_vn")
+}
+
+enum AttachmentType {
+  pdf
+  doc
+  docx
+  png
+  jpg
+  jpeg
+
+  @@map("attachment_type")
+}
+
+enum ApplyStatus {
+  applied
+  accepted
+  rejected
+  withdrawn
+
+  @@map("apply_status")
+}
+
+enum SalaryPeriod {
+  year
+  month
+  hour
+
+  @@map("salary_period")
+}
+
+model Org {
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name      String
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  users           AppUser[]
+  jobDescriptions JobDescription[]
+
+  @@map("org")
+}
+
+model AppUser {
+  id        String   @id @db.Uuid // BetterAuth user id
+  orgId     String   @map("org_id") @db.Uuid
+  role      AppRole  @default(candidate)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  org Org @relation(fields: [orgId], references: [id], onDelete: Restrict)
+
+  profilePublic  ProfilesPublic?
+  profilePrivate ProfilesPrivate?
+
+  languages     ProfileLanguage[]
+  careers       ProfileCareer[]
+  educations    ProfileEducation[]
+  urls          ProfileUrl[]
+  attachments   ProfileAttachment[]
+  profileSkills ProfileSkill[]
+
+  applies Apply[]
+
+  @@index([orgId], map: "app_users_org_idx")
+  @@map("app_users")
+}
+
+model ProfilesPublic {
+  userId    String   @id @map("user_id") @db.Uuid
+  firstName String   @default("") @map("first_name")
+  lastName  String   @default("") @map("last_name")
+  aboutMe   String?  @map("about_me")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  user AppUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("profiles_public")
+}
+
+model ProfilesPrivate {
+  userId      String   @id @map("user_id") @db.Uuid
+  phoneNumber String?  @map("phone_number")
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  user AppUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("profiles_private")
+}
+
+model ProfileLanguage {
+  id          String              @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId      String              @map("user_id") @db.Uuid
+  language    String
+  proficiency LanguageProficiency
+  sortOrder   Int                 @default(0) @map("sort_order")
+  createdAt   DateTime            @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime            @updatedAt @map("updated_at") @db.Timestamptz
+
+  user AppUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, language], map: "profile_language_user_id_language_key")
+  @@index([userId], map: "profile_language_user_idx")
+  @@map("profile_language")
+}
+
+model ProfileCareer {
+  id             String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId         String         @map("user_id") @db.Uuid
+  companyName    String         @map("company_name")
+  positionTitle  String         @map("position_title")
+  jobId          String         @map("job_id") // required
+  employmentType EmploymentType @map("employment_type")
+  startDate      DateTime       @map("start_date") @db.Date
+  endDate        DateTime?      @map("end_date") @db.Date
+  description    String?
+  sortOrder      Int            @default(0) @map("sort_order")
+  createdAt      DateTime       @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt      DateTime       @updatedAt @map("updated_at") @db.Timestamptz
+
+  user AppUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+  job  Job     @relation(fields: [jobId], references: [id], onDelete: Restrict)
+
+  @@index([userId], map: "profile_career_user_idx")
+  @@index([jobId], map: "profile_career_job_idx")
+  @@map("profile_career")
+}
+
+model ProfileEducation {
+  id              String          @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId          String          @map("user_id") @db.Uuid
+  institutionName String          @map("institution_name")
+  educationType   EducationTypeVn @map("education_type")
+  field           String?
+  isGraduated     Boolean         @default(false) @map("is_graduated")
+  startDate       DateTime        @map("start_date") @db.Date
+  endDate         DateTime?       @map("end_date") @db.Date
+  sortOrder       Int             @default(0) @map("sort_order")
+  createdAt       DateTime        @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt       DateTime        @updatedAt @map("updated_at") @db.Timestamptz
+
+  user AppUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId], map: "profile_education_user_idx")
+  @@map("profile_education")
+}
+
+model ProfileUrl {
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId    String   @map("user_id") @db.Uuid
+  label     String
+  url       String
+  sortOrder Int      @default(0) @map("sort_order")
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  user AppUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId], map: "profile_url_user_idx")
+  @@map("profile_url")
+}
+
+model ProfileAttachment {
+  id               String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId           String         @map("user_id") @db.Uuid
+  label            String?
+  fileType         AttachmentType @map("file_type")
+  mimeType         String         @map("mime_type")
+  sizeBytes        BigInt         @map("size_bytes")
+  originalFileName String         @map("original_file_name")
+  s3Bucket         String         @map("s3_bucket")
+  s3Key            String         @map("s3_key")
+  createdAt        DateTime       @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt        DateTime       @updatedAt @map("updated_at") @db.Timestamptz
+
+  user AppUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId], map: "profile_attachment_user_idx")
+  @@map("profile_attachment")
+}
+
+// Catalogs (text slug PKs)
+
+model JobFamily {
+  id            String   @id @db.Text
+  displayNameEn String   @map("display_name_en")
+  displayNameKo String?  @map("display_name_ko")
+  displayNameVi String?  @map("display_name_vi")
+  sortOrder     Int      @default(0) @map("sort_order")
+  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt     DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  jobs Job[]
+
+  @@map("job_family")
+}
+
+model Job {
+  id            String   @id @db.Text
+  jobFamilyId   String   @map("job_family_id") @db.Text
+  displayNameEn String   @map("display_name_en")
+  displayNameKo String?  @map("display_name_ko")
+  displayNameVi String?  @map("display_name_vi")
+  sortOrder     Int      @default(0) @map("sort_order")
+  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt     DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  family JobFamily @relation(fields: [jobFamilyId], references: [id], onDelete: Restrict)
+
+  careers         ProfileCareer[]
+  jobDescriptions JobDescription[]
+
+  @@index([jobFamilyId], map: "job_family_idx")
+  @@map("job")
+}
+
+model Skill {
+  id            String   @id @db.Text
+  displayNameEn String   @map("display_name_en")
+  displayNameKo String?  @map("display_name_ko")
+  displayNameVi String?  @map("display_name_vi")
+  createdAt     DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt     DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  aliases       SkillAlias[]
+  profileSkills ProfileSkill[]
+  jdSkills      JobDescriptionSkill[]
+
+  @@map("skill")
+}
+
+model SkillAlias {
+  id              String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  skillId         String   @map("skill_id") @db.Text
+  alias           String
+  aliasNormalized String   @map("alias_normalized")
+  createdAt       DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt       DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  skill Skill @relation(fields: [skillId], references: [id], onDelete: Cascade)
+
+  @@index([aliasNormalized], map: "skill_alias_norm_idx")
+  @@index([skillId], map: "skill_alias_skill_idx")
+  @@map("skill_alias")
+}
+
+model ProfileSkill {
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId    String   @map("user_id") @db.Uuid
+  skillId   String   @map("skill_id") @db.Text
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  user  AppUser @relation(fields: [userId], references: [id], onDelete: Cascade)
+  skill Skill   @relation(fields: [skillId], references: [id], onDelete: Restrict)
+
+  @@unique([userId, skillId], map: "profile_skill_user_id_skill_id_key")
+  @@index([userId], map: "profile_skill_user_idx")
+  @@index([skillId], map: "profile_skill_skill_idx")
+  @@map("profile_skill")
+}
+
+model JobDescription {
+  id                 String           @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  orgId              String           @map("org_id") @db.Uuid
+  jobId              String           @map("job_id") @db.Text
+  title              String
+  employmentType     EmploymentType   @map("employment_type")
+  workArrangement    WorkArrangement  @map("work_arrangement")
+  minYearsExperience Int?             @map("min_years_experience")
+  minEducation       EducationTypeVn? @map("min_education")
+
+  salaryMin          Int?         @map("salary_min")
+  salaryMax          Int?         @map("salary_max")
+  salaryCurrency     String       @default("VND") @map("salary_currency") @db.Char(3)
+  salaryPeriod       SalaryPeriod @default(year) @map("salary_period")
+  salaryIsNegotiable Boolean      @default(false) @map("salary_is_negotiable")
+
+  descriptionMarkdown String? @map("description_markdown")
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  org Org @relation(fields: [orgId], references: [id], onDelete: Restrict)
+  job Job @relation(fields: [jobId], references: [id], onDelete: Restrict)
+
+  skills  JobDescriptionSkill[]
+  applies Apply[]
+
+  @@index([orgId], map: "jd_org_idx")
+  @@index([jobId], map: "jd_job_idx")
+  @@map("job_description")
+}
+
+model JobDescriptionSkill {
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  jdId      String   @map("jd_id") @db.Uuid
+  skillId   String   @map("skill_id") @db.Text
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  jd    JobDescription @relation(fields: [jdId], references: [id], onDelete: Cascade)
+  skill Skill          @relation(fields: [skillId], references: [id], onDelete: Restrict)
+
+  @@unique([jdId, skillId], map: "job_description_skill_jd_id_skill_id_key")
+  @@index([jdId], map: "jd_skill_jd_idx")
+  @@index([skillId], map: "jd_skill_skill_idx")
+  @@map("job_description_skill")
+}
+
+model Apply {
+  id        String      @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId    String      @map("user_id") @db.Uuid
+  jdId      String      @map("jd_id") @db.Uuid
+  status    ApplyStatus @default(applied)
+  createdAt DateTime    @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime    @updatedAt @map("updated_at") @db.Timestamptz
+
+  user AppUser        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  jd   JobDescription @relation(fields: [jdId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, jdId], map: "apply_user_id_jd_id_key")
+  @@index([userId], map: "apply_user_idx")
+  @@index([jdId], map: "apply_jd_idx")
+  @@map("apply")
+}


### PR DESCRIPTION
## 요약
- 모든 모델의 `updatedAt` 필드에 `@updatedAt` 적용 (기존 `@default(now())`는 INSERT 시에만 설정됨)
- `ProfileLanguage`에 `@@unique([userId, language])` 제약 조건 추가
- `JobDescription`에 `orgId` 필드, `Org` 관계 및 인덱스 추가
- `ApplyStatus` 열거형 추가 및 `Apply` 모델에 `status` 필드 추가
- `SalaryPeriod` 열거형 추가, `JobDescription`의 자유 문자열 대체

## 테스트 계획
- [ ] `prisma validate` 통과 확인
- [ ] `prisma generate` 정상 동작 확인
- [ ] 마이그레이션 적용 후 DB 스키마 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)