### PR TITLE
docs: 문서 가이드라인 한국어 작성 범위 명확화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,4 +115,5 @@ YOU MUST follow this debugging framework for ANY technical issue:
 
 ## Documentation Guidelines
 
-- Every documentation directed to "Ori" needs to be in Korean
+- Conversation with Ori is in English
+- All other written artifacts must be in Korean: PR titles/descriptions, commit messages, code comments, documentation files, and issue descriptions


### PR DESCRIPTION
## 요약
- Ori와의 대화는 영어로 유지
- PR, 커밋 메시지, 코드 코멘트, 문서 파일 등 모든 산출물은 한국어로 작성하도록 명확화

## 테스트 계획
- [ ] CLAUDE.md 내용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)