### PR TITLE
feat: Prompt 4 — Auth Client + Session Helpers

### DIFF
--- a/__tests__/lib/infrastructure/auth-utils.test.ts
+++ b/__tests__/lib/infrastructure/auth-utils.test.ts
@@ -1,0 +1,67 @@
+jest.mock('@/lib/infrastructure/auth', () => ({
+  auth: { api: { getSession: jest.fn() } },
+}))
+jest.mock('@/lib/infrastructure/db', () => ({
+  prisma: { appUser: { findUnique: jest.fn() } },
+}))
+jest.mock('next/headers', () => ({
+  headers: jest.fn().mockResolvedValue(new Headers()),
+}))
+
+import { auth } from '@/lib/infrastructure/auth'
+import { prisma } from '@/lib/infrastructure/db'
+import { getCurrentUser, requireUser, requireRole } from '@/lib/infrastructure/auth-utils'
+
+const mockGetSession = auth.api.getSession as unknown as jest.Mock
+const mockFindUnique = prisma.appUser.findUnique as unknown as jest.Mock
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('getCurrentUser', () => {
+  it('세션 없으면 null 반환', async () => {
+    mockGetSession.mockResolvedValue(null)
+    expect(await getCurrentUser()).toBeNull()
+  })
+
+  it('세션 있지만 appUser 없으면 null 반환', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', email: 'a@b.com' } })
+    mockFindUnique.mockResolvedValue(null)
+    expect(await getCurrentUser()).toBeNull()
+  })
+
+  it('세션 + appUser 있으면 유저 컨텍스트 반환', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', email: 'a@b.com' } })
+    mockFindUnique.mockResolvedValue({ role: 'candidate', orgId: null })
+    const user = await getCurrentUser()
+    expect(user).toEqual({ userId: 'u1', email: 'a@b.com', role: 'candidate', orgId: null })
+  })
+})
+
+describe('requireUser', () => {
+  it('인증된 유저 반환', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', email: 'a@b.com' } })
+    mockFindUnique.mockResolvedValue({ role: 'candidate', orgId: null })
+    await expect(requireUser()).resolves.toMatchObject({ userId: 'u1' })
+  })
+
+  it('미인증 시 throw', async () => {
+    mockGetSession.mockResolvedValue(null)
+    await expect(requireUser()).rejects.toThrow()
+  })
+})
+
+describe('requireRole', () => {
+  it('올바른 역할이면 유저 반환', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', email: 'a@b.com' } })
+    mockFindUnique.mockResolvedValue({ role: 'recruiter', orgId: 'org1' })
+    await expect(requireRole('recruiter', 'admin')).resolves.toMatchObject({ role: 'recruiter' })
+  })
+
+  it('잘못된 역할이면 throw', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', email: 'a@b.com' } })
+    mockFindUnique.mockResolvedValue({ role: 'candidate', orgId: null })
+    await expect(requireRole('recruiter', 'admin')).rejects.toThrow()
+  })
+})

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -103,7 +103,7 @@ middleware.ts
 | 1   | Jest + Prisma Client + Env  | Foundation        | 테스트 러너, DB 싱글턴         | ✅   |
 | 2   | BetterAuth Schema + Seed    | Foundation        | DB 테이블, 카탈로그 데이터     | 🔶   |
 | 3   | BetterAuth Server + API     | Auth              | 인증 인스턴스, API 엔드포인트  | ✅   |
-| 4   | Auth Client + Session       | Auth              | 클라이언트 SDK, getCurrentUser | ⬜   |
+| 4   | Auth Client + Session       | Auth              | 클라이언트 SDK, getCurrentUser | ✅   |
 | 5   | Middleware + Signup Hooks   | Auth              | 라우트 보호, 유저 프로비저닝   | ⬜   |
 | 6   | Zod Schemas                 | Validation        | 전체 도메인 입력 검증          | ⬜   |
 | 7   | Authorization + Errors      | Domain            | 접근 제어, 도메인 에러         | ⬜   |
@@ -334,6 +334,21 @@ Task 3: __tests__/lib/infrastructure/auth-utils.test.ts 테스트.
 
 검증: pnpm test 통과.
 ```
+
+#### Prompt 4 결과
+
+**상태**: ✅ 완료 (커밋: `561eb12`)
+
+완료 항목:
+
+- `lib/infrastructure/auth-client.ts`: `createAuthClient` from `better-auth/react`. `useSession`, `signIn`, `signUp`, `signOut` export.
+- `lib/infrastructure/auth-utils.ts`: `getCurrentUser` (세션 없음/appUser 없음 시 null), `requireUser` (미인증 시 throw), `requireRole` (역할 불일치 시 throw). `UserContext` 타입 export.
+- `__tests__/lib/infrastructure/auth-utils.test.ts`: 7개 테스트 모두 통과.
+
+계획 대비 변경 사항:
+
+- `AppRole` import: 계획에서 `@/lib/generated/prisma`로 명시했으나 실제 출력 구조상 `@/lib/generated/prisma/enums`에서 import. Prisma 7 생성기는 index 없이 개별 파일로 분리 출력.
+- 테스트 mock 캐스팅: `as jest.Mock` → `as unknown as jest.Mock`. TypeScript가 BetterAuth의 `getSession` 타입과 `jest.Mock` 간 오버랩 부족으로 직접 캐스팅 불허.
 
 ---
 

--- a/lib/infrastructure/auth-client.ts
+++ b/lib/infrastructure/auth-client.ts
@@ -1,0 +1,5 @@
+import { createAuthClient } from 'better-auth/react'
+
+export const { useSession, signIn, signUp, signOut } = createAuthClient({
+  baseURL: process.env.NEXT_PUBLIC_APP_URL,
+})

--- a/lib/infrastructure/auth-utils.ts
+++ b/lib/infrastructure/auth-utils.ts
@@ -1,0 +1,41 @@
+import { headers } from 'next/headers'
+import { auth } from '@/lib/infrastructure/auth'
+import { prisma } from '@/lib/infrastructure/db'
+import { AppRole } from '@/lib/generated/prisma/enums'
+
+export type UserContext = {
+  userId: string
+  email: string
+  role: AppRole
+  orgId: string | null
+}
+
+export async function getCurrentUser(): Promise<UserContext | null> {
+  const session = await auth.api.getSession({ headers: await headers() })
+  if (!session) return null
+
+  const appUser = await prisma.appUser.findUnique({
+    where: { id: session.user.id },
+    select: { role: true, orgId: true },
+  })
+  if (!appUser) return null
+
+  return {
+    userId: session.user.id,
+    email: session.user.email,
+    role: appUser.role,
+    orgId: appUser.orgId,
+  }
+}
+
+export async function requireUser(): Promise<UserContext> {
+  const user = await getCurrentUser()
+  if (!user) throw new Error('Unauthorized')
+  return user
+}
+
+export async function requireRole(...roles: AppRole[]): Promise<UserContext> {
+  const user = await requireUser()
+  if (!roles.includes(user.role)) throw new Error('Forbidden')
+  return user
+}


### PR DESCRIPTION
## 요약

- `lib/infrastructure/auth-client.ts`: `better-auth/react`의 `createAuthClient`로 `useSession`, `signIn`, `signUp`, `signOut` export
- `lib/infrastructure/auth-utils.ts`: `getCurrentUser`, `requireUser`, `requireRole` 서버 세션 헬퍼. `UserContext` 타입 export
- `__tests__/lib/infrastructure/auth-utils.test.ts`: 7개 테스트 (세션 없음/appUser 없음/정상, 인증/미인증, 역할 검증)

## 테스트 계획

- [ ] `pnpm test` — 3개 테스트 스위트 10개 테스트 모두 통과 확인
- [ ] `pnpm exec tsc --noEmit` — 타입 에러 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)