### PR TITLE
feat: Zod 검증 스키마 추가 (Prompt 6)

### DIFF
--- a/__tests__/lib/validations/application.test.ts
+++ b/__tests__/lib/validations/application.test.ts
@@ -1,0 +1,13 @@
+import { applySchema } from '@/lib/validations/application'
+
+describe('applySchema', () => {
+  it('유효한 UUID 통과', () => {
+    expect(applySchema.safeParse({ jdId: '123e4567-e89b-12d3-a456-426614174000' }).success).toBe(true)
+  })
+  it('UUID 형식이 아니면 거부', () => {
+    expect(applySchema.safeParse({ jdId: 'not-a-uuid' }).success).toBe(false)
+  })
+  it('jdId 누락 시 거부', () => {
+    expect(applySchema.safeParse({}).success).toBe(false)
+  })
+})

--- a/__tests__/lib/validations/application.test.ts
+++ b/__tests__/lib/validations/application.test.ts
@@ -1,13 +1,16 @@
-import { applySchema } from '@/lib/validations/application'
+import { applySchema } from '@/lib/validations/application';
 
 describe('applySchema', () => {
   it('유효한 UUID 통과', () => {
-    expect(applySchema.safeParse({ jdId: '123e4567-e89b-12d3-a456-426614174000' }).success).toBe(true)
-  })
+    expect(
+      applySchema.safeParse({ jdId: '123e4567-e89b-12d3-a456-426614174000' })
+        .success
+    ).toBe(true);
+  });
   it('UUID 형식이 아니면 거부', () => {
-    expect(applySchema.safeParse({ jdId: 'not-a-uuid' }).success).toBe(false)
-  })
+    expect(applySchema.safeParse({ jdId: 'not-a-uuid' }).success).toBe(false);
+  });
   it('jdId 누락 시 거부', () => {
-    expect(applySchema.safeParse({}).success).toBe(false)
-  })
-})
+    expect(applySchema.safeParse({}).success).toBe(false);
+  });
+});

--- a/__tests__/lib/validations/job-description.test.ts
+++ b/__tests__/lib/validations/job-description.test.ts
@@ -1,0 +1,30 @@
+import { jobDescriptionFilterSchema } from '@/lib/validations/job-description'
+
+describe('jobDescriptionFilterSchema', () => {
+  it('빈 객체에 기본값 적용', () => {
+    const result = jobDescriptionFilterSchema.parse({})
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(20)
+  })
+  it('유효한 필터 통과', () => {
+    expect(jobDescriptionFilterSchema.safeParse({
+      jobId: 'software-engineer',
+      employmentType: 'full_time',
+      workArrangement: 'remote',
+      page: 2,
+      pageSize: 10,
+    }).success).toBe(true)
+  })
+  it('pageSize 51 거부', () => {
+    expect(jobDescriptionFilterSchema.safeParse({ pageSize: 51 }).success).toBe(false)
+  })
+  it('page 0 거부', () => {
+    expect(jobDescriptionFilterSchema.safeParse({ page: 0 }).success).toBe(false)
+  })
+  it('잘못된 employmentType 거부', () => {
+    expect(jobDescriptionFilterSchema.safeParse({ employmentType: 'contract' }).success).toBe(false)
+  })
+  it('잘못된 workArrangement 거부', () => {
+    expect(jobDescriptionFilterSchema.safeParse({ workArrangement: 'wfh' }).success).toBe(false)
+  })
+})

--- a/__tests__/lib/validations/job-description.test.ts
+++ b/__tests__/lib/validations/job-description.test.ts
@@ -1,30 +1,41 @@
-import { jobDescriptionFilterSchema } from '@/lib/validations/job-description'
+import { jobDescriptionFilterSchema } from '@/lib/validations/job-description';
 
 describe('jobDescriptionFilterSchema', () => {
   it('빈 객체에 기본값 적용', () => {
-    const result = jobDescriptionFilterSchema.parse({})
-    expect(result.page).toBe(1)
-    expect(result.pageSize).toBe(20)
-  })
+    const result = jobDescriptionFilterSchema.parse({});
+    expect(result.page).toBe(1);
+    expect(result.pageSize).toBe(20);
+  });
   it('유효한 필터 통과', () => {
-    expect(jobDescriptionFilterSchema.safeParse({
-      jobId: 'software-engineer',
-      employmentType: 'full_time',
-      workArrangement: 'remote',
-      page: 2,
-      pageSize: 10,
-    }).success).toBe(true)
-  })
+    expect(
+      jobDescriptionFilterSchema.safeParse({
+        jobId: 'software-engineer',
+        employmentType: 'full_time',
+        workArrangement: 'remote',
+        page: 2,
+        pageSize: 10,
+      }).success
+    ).toBe(true);
+  });
   it('pageSize 51 거부', () => {
-    expect(jobDescriptionFilterSchema.safeParse({ pageSize: 51 }).success).toBe(false)
-  })
+    expect(jobDescriptionFilterSchema.safeParse({ pageSize: 51 }).success).toBe(
+      false
+    );
+  });
   it('page 0 거부', () => {
-    expect(jobDescriptionFilterSchema.safeParse({ page: 0 }).success).toBe(false)
-  })
+    expect(jobDescriptionFilterSchema.safeParse({ page: 0 }).success).toBe(
+      false
+    );
+  });
   it('잘못된 employmentType 거부', () => {
-    expect(jobDescriptionFilterSchema.safeParse({ employmentType: 'contract' }).success).toBe(false)
-  })
+    expect(
+      jobDescriptionFilterSchema.safeParse({ employmentType: 'contract' })
+        .success
+    ).toBe(false);
+  });
   it('잘못된 workArrangement 거부', () => {
-    expect(jobDescriptionFilterSchema.safeParse({ workArrangement: 'wfh' }).success).toBe(false)
-  })
-})
+    expect(
+      jobDescriptionFilterSchema.safeParse({ workArrangement: 'wfh' }).success
+    ).toBe(false);
+  });
+});

--- a/__tests__/lib/validations/profile.test.ts
+++ b/__tests__/lib/validations/profile.test.ts
@@ -1,0 +1,114 @@
+import {
+  profilePublicSchema,
+  profilePrivateSchema,
+  profileLanguageSchema,
+  profileCareerSchema,
+  profileEducationSchema,
+  profileUrlSchema,
+  profileSkillSchema,
+} from '@/lib/validations/profile'
+
+describe('profilePublicSchema', () => {
+  it('유효한 데이터 통과', () => {
+    expect(profilePublicSchema.safeParse({ firstName: 'Ori', lastName: 'Kim', aboutMe: '안녕' }).success).toBe(true)
+  })
+  it('빈 firstName 거부', () => {
+    expect(profilePublicSchema.safeParse({ firstName: '', lastName: 'Kim' }).success).toBe(false)
+  })
+  it('aboutMe 2000자 초과 거부', () => {
+    expect(profilePublicSchema.safeParse({ firstName: 'A', lastName: 'B', aboutMe: 'x'.repeat(2001) }).success).toBe(false)
+  })
+  it('aboutMe 없어도 통과', () => {
+    expect(profilePublicSchema.safeParse({ firstName: 'A', lastName: 'B' }).success).toBe(true)
+  })
+})
+
+describe('profilePrivateSchema', () => {
+  it('유효한 전화번호 통과', () => {
+    expect(profilePrivateSchema.safeParse({ phoneNumber: '+84 123 456 789' }).success).toBe(true)
+  })
+  it('형식 불일치 전화번호 거부', () => {
+    expect(profilePrivateSchema.safeParse({ phoneNumber: 'abc' }).success).toBe(false)
+  })
+  it('phoneNumber 없어도 통과', () => {
+    expect(profilePrivateSchema.safeParse({}).success).toBe(true)
+  })
+})
+
+describe('profileLanguageSchema', () => {
+  it('유효한 데이터 통과', () => {
+    expect(profileLanguageSchema.safeParse({ language: 'Korean', proficiency: 'native', sortOrder: 0 }).success).toBe(true)
+  })
+  it('잘못된 proficiency 거부', () => {
+    expect(profileLanguageSchema.safeParse({ language: 'Korean', proficiency: 'expert', sortOrder: 0 }).success).toBe(false)
+  })
+})
+
+describe('profileCareerSchema', () => {
+  const valid = {
+    companyName: 'Acme',
+    positionTitle: 'Engineer',
+    jobId: 'software-engineer',
+    employmentType: 'full_time',
+    startDate: '2022-01-01',
+    sortOrder: 0,
+  }
+  it('유효한 데이터 통과', () => {
+    expect(profileCareerSchema.safeParse(valid).success).toBe(true)
+  })
+  it('endDate가 startDate 이전이면 거부', () => {
+    expect(profileCareerSchema.safeParse({ ...valid, startDate: '2023-01-01', endDate: '2022-01-01' }).success).toBe(false)
+  })
+  it('endDate === startDate 통과', () => {
+    expect(profileCareerSchema.safeParse({ ...valid, startDate: '2022-01-01', endDate: '2022-01-01' }).success).toBe(true)
+  })
+  it('잘못된 날짜 형식 거부', () => {
+    expect(profileCareerSchema.safeParse({ ...valid, startDate: '2022/01/01' }).success).toBe(false)
+  })
+  it('잘못된 employmentType 거부', () => {
+    expect(profileCareerSchema.safeParse({ ...valid, employmentType: 'contract' }).success).toBe(false)
+  })
+  it('description 5000자 초과 거부', () => {
+    expect(profileCareerSchema.safeParse({ ...valid, description: 'x'.repeat(5001) }).success).toBe(false)
+  })
+})
+
+describe('profileEducationSchema', () => {
+  const valid = {
+    institutionName: 'Seoul Univ',
+    educationType: 'higher_bachelor',
+    isGraduated: true,
+    startDate: '2018-03-01',
+    sortOrder: 0,
+  }
+  it('유효한 데이터 통과', () => {
+    expect(profileEducationSchema.safeParse(valid).success).toBe(true)
+  })
+  it('endDate가 startDate 이전이면 거부', () => {
+    expect(profileEducationSchema.safeParse({ ...valid, startDate: '2023-01-01', endDate: '2020-01-01' }).success).toBe(false)
+  })
+  it('잘못된 educationType 거부', () => {
+    expect(profileEducationSchema.safeParse({ ...valid, educationType: 'bachelor' }).success).toBe(false)
+  })
+})
+
+describe('profileUrlSchema', () => {
+  it('유효한 URL 통과', () => {
+    expect(profileUrlSchema.safeParse({ label: 'GitHub', url: 'https://github.com/ori', sortOrder: 0 }).success).toBe(true)
+  })
+  it('http가 아닌 URL 거부', () => {
+    expect(profileUrlSchema.safeParse({ label: 'Ftp', url: 'ftp://example.com', sortOrder: 0 }).success).toBe(false)
+  })
+  it('빈 label 거부', () => {
+    expect(profileUrlSchema.safeParse({ label: '', url: 'https://github.com', sortOrder: 0 }).success).toBe(false)
+  })
+})
+
+describe('profileSkillSchema', () => {
+  it('유효한 skillId 통과', () => {
+    expect(profileSkillSchema.safeParse({ skillId: 'typescript' }).success).toBe(true)
+  })
+  it('빈 skillId 거부', () => {
+    expect(profileSkillSchema.safeParse({ skillId: '' }).success).toBe(false)
+  })
+})

--- a/__tests__/lib/validations/profile.test.ts
+++ b/__tests__/lib/validations/profile.test.ts
@@ -6,43 +6,75 @@ import {
   profileEducationSchema,
   profileUrlSchema,
   profileSkillSchema,
-} from '@/lib/validations/profile'
+} from '@/lib/validations/profile';
 
 describe('profilePublicSchema', () => {
   it('유효한 데이터 통과', () => {
-    expect(profilePublicSchema.safeParse({ firstName: 'Ori', lastName: 'Kim', aboutMe: '안녕' }).success).toBe(true)
-  })
+    expect(
+      profilePublicSchema.safeParse({
+        firstName: 'Ori',
+        lastName: 'Kim',
+        aboutMe: '안녕',
+      }).success
+    ).toBe(true);
+  });
   it('빈 firstName 거부', () => {
-    expect(profilePublicSchema.safeParse({ firstName: '', lastName: 'Kim' }).success).toBe(false)
-  })
+    expect(
+      profilePublicSchema.safeParse({ firstName: '', lastName: 'Kim' }).success
+    ).toBe(false);
+  });
   it('aboutMe 2000자 초과 거부', () => {
-    expect(profilePublicSchema.safeParse({ firstName: 'A', lastName: 'B', aboutMe: 'x'.repeat(2001) }).success).toBe(false)
-  })
+    expect(
+      profilePublicSchema.safeParse({
+        firstName: 'A',
+        lastName: 'B',
+        aboutMe: 'x'.repeat(2001),
+      }).success
+    ).toBe(false);
+  });
   it('aboutMe 없어도 통과', () => {
-    expect(profilePublicSchema.safeParse({ firstName: 'A', lastName: 'B' }).success).toBe(true)
-  })
-})
+    expect(
+      profilePublicSchema.safeParse({ firstName: 'A', lastName: 'B' }).success
+    ).toBe(true);
+  });
+});
 
 describe('profilePrivateSchema', () => {
   it('유효한 전화번호 통과', () => {
-    expect(profilePrivateSchema.safeParse({ phoneNumber: '+84 123 456 789' }).success).toBe(true)
-  })
+    expect(
+      profilePrivateSchema.safeParse({ phoneNumber: '+84 123 456 789' }).success
+    ).toBe(true);
+  });
   it('형식 불일치 전화번호 거부', () => {
-    expect(profilePrivateSchema.safeParse({ phoneNumber: 'abc' }).success).toBe(false)
-  })
+    expect(profilePrivateSchema.safeParse({ phoneNumber: 'abc' }).success).toBe(
+      false
+    );
+  });
   it('phoneNumber 없어도 통과', () => {
-    expect(profilePrivateSchema.safeParse({}).success).toBe(true)
-  })
-})
+    expect(profilePrivateSchema.safeParse({}).success).toBe(true);
+  });
+});
 
 describe('profileLanguageSchema', () => {
   it('유효한 데이터 통과', () => {
-    expect(profileLanguageSchema.safeParse({ language: 'Korean', proficiency: 'native', sortOrder: 0 }).success).toBe(true)
-  })
+    expect(
+      profileLanguageSchema.safeParse({
+        language: 'Korean',
+        proficiency: 'native',
+        sortOrder: 0,
+      }).success
+    ).toBe(true);
+  });
   it('잘못된 proficiency 거부', () => {
-    expect(profileLanguageSchema.safeParse({ language: 'Korean', proficiency: 'expert', sortOrder: 0 }).success).toBe(false)
-  })
-})
+    expect(
+      profileLanguageSchema.safeParse({
+        language: 'Korean',
+        proficiency: 'expert',
+        sortOrder: 0,
+      }).success
+    ).toBe(false);
+  });
+});
 
 describe('profileCareerSchema', () => {
   const valid = {
@@ -52,26 +84,47 @@ describe('profileCareerSchema', () => {
     employmentType: 'full_time',
     startDate: '2022-01-01',
     sortOrder: 0,
-  }
+  };
   it('유효한 데이터 통과', () => {
-    expect(profileCareerSchema.safeParse(valid).success).toBe(true)
-  })
+    expect(profileCareerSchema.safeParse(valid).success).toBe(true);
+  });
   it('endDate가 startDate 이전이면 거부', () => {
-    expect(profileCareerSchema.safeParse({ ...valid, startDate: '2023-01-01', endDate: '2022-01-01' }).success).toBe(false)
-  })
+    expect(
+      profileCareerSchema.safeParse({
+        ...valid,
+        startDate: '2023-01-01',
+        endDate: '2022-01-01',
+      }).success
+    ).toBe(false);
+  });
   it('endDate === startDate 통과', () => {
-    expect(profileCareerSchema.safeParse({ ...valid, startDate: '2022-01-01', endDate: '2022-01-01' }).success).toBe(true)
-  })
+    expect(
+      profileCareerSchema.safeParse({
+        ...valid,
+        startDate: '2022-01-01',
+        endDate: '2022-01-01',
+      }).success
+    ).toBe(true);
+  });
   it('잘못된 날짜 형식 거부', () => {
-    expect(profileCareerSchema.safeParse({ ...valid, startDate: '2022/01/01' }).success).toBe(false)
-  })
+    expect(
+      profileCareerSchema.safeParse({ ...valid, startDate: '2022/01/01' })
+        .success
+    ).toBe(false);
+  });
   it('잘못된 employmentType 거부', () => {
-    expect(profileCareerSchema.safeParse({ ...valid, employmentType: 'contract' }).success).toBe(false)
-  })
+    expect(
+      profileCareerSchema.safeParse({ ...valid, employmentType: 'contract' })
+        .success
+    ).toBe(false);
+  });
   it('description 5000자 초과 거부', () => {
-    expect(profileCareerSchema.safeParse({ ...valid, description: 'x'.repeat(5001) }).success).toBe(false)
-  })
-})
+    expect(
+      profileCareerSchema.safeParse({ ...valid, description: 'x'.repeat(5001) })
+        .success
+    ).toBe(false);
+  });
+});
 
 describe('profileEducationSchema', () => {
   const valid = {
@@ -80,35 +133,64 @@ describe('profileEducationSchema', () => {
     isGraduated: true,
     startDate: '2018-03-01',
     sortOrder: 0,
-  }
+  };
   it('유효한 데이터 통과', () => {
-    expect(profileEducationSchema.safeParse(valid).success).toBe(true)
-  })
+    expect(profileEducationSchema.safeParse(valid).success).toBe(true);
+  });
   it('endDate가 startDate 이전이면 거부', () => {
-    expect(profileEducationSchema.safeParse({ ...valid, startDate: '2023-01-01', endDate: '2020-01-01' }).success).toBe(false)
-  })
+    expect(
+      profileEducationSchema.safeParse({
+        ...valid,
+        startDate: '2023-01-01',
+        endDate: '2020-01-01',
+      }).success
+    ).toBe(false);
+  });
   it('잘못된 educationType 거부', () => {
-    expect(profileEducationSchema.safeParse({ ...valid, educationType: 'bachelor' }).success).toBe(false)
-  })
-})
+    expect(
+      profileEducationSchema.safeParse({ ...valid, educationType: 'bachelor' })
+        .success
+    ).toBe(false);
+  });
+});
 
 describe('profileUrlSchema', () => {
   it('유효한 URL 통과', () => {
-    expect(profileUrlSchema.safeParse({ label: 'GitHub', url: 'https://github.com/ori', sortOrder: 0 }).success).toBe(true)
-  })
+    expect(
+      profileUrlSchema.safeParse({
+        label: 'GitHub',
+        url: 'https://github.com/ori',
+        sortOrder: 0,
+      }).success
+    ).toBe(true);
+  });
   it('http가 아닌 URL 거부', () => {
-    expect(profileUrlSchema.safeParse({ label: 'Ftp', url: 'ftp://example.com', sortOrder: 0 }).success).toBe(false)
-  })
+    expect(
+      profileUrlSchema.safeParse({
+        label: 'Ftp',
+        url: 'ftp://example.com',
+        sortOrder: 0,
+      }).success
+    ).toBe(false);
+  });
   it('빈 label 거부', () => {
-    expect(profileUrlSchema.safeParse({ label: '', url: 'https://github.com', sortOrder: 0 }).success).toBe(false)
-  })
-})
+    expect(
+      profileUrlSchema.safeParse({
+        label: '',
+        url: 'https://github.com',
+        sortOrder: 0,
+      }).success
+    ).toBe(false);
+  });
+});
 
 describe('profileSkillSchema', () => {
   it('유효한 skillId 통과', () => {
-    expect(profileSkillSchema.safeParse({ skillId: 'typescript' }).success).toBe(true)
-  })
+    expect(
+      profileSkillSchema.safeParse({ skillId: 'typescript' }).success
+    ).toBe(true);
+  });
   it('빈 skillId 거부', () => {
-    expect(profileSkillSchema.safeParse({ skillId: '' }).success).toBe(false)
-  })
-})
+    expect(profileSkillSchema.safeParse({ skillId: '' }).success).toBe(false);
+  });
+});

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -103,9 +103,9 @@ middleware.ts
 | 1   | Jest + Prisma Client + Env  | Foundation        | 테스트 러너, DB 싱글턴         | ✅   |
 | 2   | BetterAuth Schema + Seed    | Foundation        | DB 테이블, 카탈로그 데이터     | 🔶   |
 | 3   | BetterAuth Server + API     | Auth              | 인증 인스턴스, API 엔드포인트  | ✅   |
-| 4   | Auth Client + Session       | Auth              | 클라이언트 SDK, getCurrentUser | ⬜   |
-| 5   | Middleware + Signup Hooks   | Auth              | 라우트 보호, 유저 프로비저닝   | ⬜   |
-| 6   | Zod Schemas                 | Validation        | 전체 도메인 입력 검증          | ⬜   |
+| 4   | Auth Client + Session       | Auth              | 클라이언트 SDK, getCurrentUser | ✅   |
+| 5   | Middleware + Signup Hooks   | Auth              | 라우트 보호, 유저 프로비저닝   | ✅   |
+| 6   | Zod Schemas                 | Validation        | 전체 도메인 입력 검증          | ✅   |
 | 7   | Authorization + Errors      | Domain            | 접근 제어, 도메인 에러         | ⬜   |
 | 8   | Profile Use-Cases + Actions | Data              | 프로필 CRUD (15+ 액션)         | ⬜   |
 | 9   | Catalog + JD Queries        | Data              | 카탈로그/채용공고 조회         | ⬜   |
@@ -404,6 +404,22 @@ Task 4: 각 파일에 대한 테스트 작성.
 
 검증: pnpm test 통과. 모든 스키마가 유효하지 않은 데이터를 명확히 거부.
 ```
+
+#### Prompt 6 결과
+
+**상태**: ✅ 완료 (커밋: `70606cd`)
+
+완료 항목:
+
+- `lib/validations/profile.ts`: 7개 스키마 (profilePublic/Private/Language/Career/Education/Url/Skill). Career/Education에 날짜 순서 정제 (`.refine()`).
+- `lib/validations/application.ts`: `applySchema` — UUID 검증.
+- `lib/validations/job-description.ts`: `jobDescriptionFilterSchema` — page/pageSize 기본값, enum 필터.
+- `__tests__/lib/validations/*.test.ts`: 32개 테스트 전체 통과.
+
+계획 대비 변경 사항:
+
+- `z.string().url()`이 ftp URI를 허용함 — `.refine(val => val.startsWith('http://') || val.startsWith('https://'))`로 추가 제한.
+- `z.nativeEnum(PrismaEnum)` 대신 `z.enum([...])` 사용 — gitignored 생성 디렉터리 의존 회피.
 
 ---
 

--- a/lib/validations/application.ts
+++ b/lib/validations/application.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod'
+
+export const applySchema = z.object({
+  jdId: z.string().uuid(),
+})

--- a/lib/validations/application.ts
+++ b/lib/validations/application.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod'
+import { z } from 'zod';
 
 export const applySchema = z.object({
   jdId: z.string().uuid(),
-})
+});

--- a/lib/validations/job-description.ts
+++ b/lib/validations/job-description.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod'
+
+export const jobDescriptionFilterSchema = z.object({
+  jobId: z.string().optional(),
+  employmentType: z.enum(['full_time', 'part_time', 'intern', 'freelance']).optional(),
+  workArrangement: z.enum(['onsite', 'hybrid', 'remote']).optional(),
+  page: z.number().int().min(1).default(1),
+  pageSize: z.number().int().min(1).max(50).default(20),
+})

--- a/lib/validations/job-description.ts
+++ b/lib/validations/job-description.ts
@@ -1,9 +1,11 @@
-import { z } from 'zod'
+import { z } from 'zod';
 
 export const jobDescriptionFilterSchema = z.object({
   jobId: z.string().optional(),
-  employmentType: z.enum(['full_time', 'part_time', 'intern', 'freelance']).optional(),
+  employmentType: z
+    .enum(['full_time', 'part_time', 'intern', 'freelance'])
+    .optional(),
   workArrangement: z.enum(['onsite', 'hybrid', 'remote']).optional(),
   page: z.number().int().min(1).default(1),
   pageSize: z.number().int().min(1).max(50).default(20),
-})
+});

--- a/lib/validations/profile.ts
+++ b/lib/validations/profile.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod'
+
+export const profilePublicSchema = z.object({
+  firstName: z.string().min(1).max(100),
+  lastName: z.string().min(1).max(100),
+  aboutMe: z.string().max(2000).optional(),
+})
+
+export const profilePrivateSchema = z.object({
+  phoneNumber: z.string().regex(/^\+?[\d\s\-().]{7,20}$/).optional(),
+})
+
+export const profileLanguageSchema = z.object({
+  language: z.string().min(1),
+  proficiency: z.enum(['native', 'fluent', 'professional', 'basic']),
+  sortOrder: z.number().int().min(0),
+})
+
+export const profileCareerSchema = z.object({
+  companyName: z.string().min(1),
+  positionTitle: z.string().min(1),
+  jobId: z.string().min(1),
+  employmentType: z.enum(['full_time', 'part_time', 'intern', 'freelance']),
+  startDate: z.string().date(),
+  endDate: z.string().date().optional(),
+  description: z.string().max(5000).optional(),
+  sortOrder: z.number().int().min(0),
+}).refine(
+  (data) => !data.endDate || data.endDate >= data.startDate,
+  { message: '종료일은 시작일 이후여야 합니다', path: ['endDate'] },
+)
+
+export const profileEducationSchema = z.object({
+  institutionName: z.string().min(1),
+  educationType: z.enum([
+    'vet_elementary', 'vet_intermediate', 'vet_college',
+    'higher_bachelor', 'higher_master', 'higher_doctorate',
+    'continuing_education', 'international_program', 'other',
+  ]),
+  field: z.string().optional(),
+  isGraduated: z.boolean(),
+  startDate: z.string().date(),
+  endDate: z.string().date().optional(),
+  sortOrder: z.number().int().min(0),
+}).refine(
+  (data) => !data.endDate || data.endDate >= data.startDate,
+  { message: '종료일은 시작일 이후여야 합니다', path: ['endDate'] },
+)
+
+export const profileUrlSchema = z.object({
+  label: z.string().min(1),
+  url: z.string().url().refine(
+    (val) => val.startsWith('http://') || val.startsWith('https://'),
+    { message: 'http 또는 https URL이어야 합니다' },
+  ),
+  sortOrder: z.number().int().min(0),
+})
+
+export const profileSkillSchema = z.object({
+  skillId: z.string().min(1),
+})

--- a/lib/validations/profile.ts
+++ b/lib/validations/profile.ts
@@ -1,61 +1,76 @@
-import { z } from 'zod'
+import { z } from 'zod';
 
 export const profilePublicSchema = z.object({
   firstName: z.string().min(1).max(100),
   lastName: z.string().min(1).max(100),
   aboutMe: z.string().max(2000).optional(),
-})
+});
 
 export const profilePrivateSchema = z.object({
-  phoneNumber: z.string().regex(/^\+?[\d\s\-().]{7,20}$/).optional(),
-})
+  phoneNumber: z
+    .string()
+    .regex(/^\+?[\d\s\-().]{7,20}$/)
+    .optional(),
+});
 
 export const profileLanguageSchema = z.object({
   language: z.string().min(1),
   proficiency: z.enum(['native', 'fluent', 'professional', 'basic']),
   sortOrder: z.number().int().min(0),
-})
+});
 
-export const profileCareerSchema = z.object({
-  companyName: z.string().min(1),
-  positionTitle: z.string().min(1),
-  jobId: z.string().min(1),
-  employmentType: z.enum(['full_time', 'part_time', 'intern', 'freelance']),
-  startDate: z.string().date(),
-  endDate: z.string().date().optional(),
-  description: z.string().max(5000).optional(),
-  sortOrder: z.number().int().min(0),
-}).refine(
-  (data) => !data.endDate || data.endDate >= data.startDate,
-  { message: '종료일은 시작일 이후여야 합니다', path: ['endDate'] },
-)
+export const profileCareerSchema = z
+  .object({
+    companyName: z.string().min(1),
+    positionTitle: z.string().min(1),
+    jobId: z.string().min(1),
+    employmentType: z.enum(['full_time', 'part_time', 'intern', 'freelance']),
+    startDate: z.string().date(),
+    endDate: z.string().date().optional(),
+    description: z.string().max(5000).optional(),
+    sortOrder: z.number().int().min(0),
+  })
+  .refine((data) => !data.endDate || data.endDate >= data.startDate, {
+    message: '종료일은 시작일 이후여야 합니다',
+    path: ['endDate'],
+  });
 
-export const profileEducationSchema = z.object({
-  institutionName: z.string().min(1),
-  educationType: z.enum([
-    'vet_elementary', 'vet_intermediate', 'vet_college',
-    'higher_bachelor', 'higher_master', 'higher_doctorate',
-    'continuing_education', 'international_program', 'other',
-  ]),
-  field: z.string().optional(),
-  isGraduated: z.boolean(),
-  startDate: z.string().date(),
-  endDate: z.string().date().optional(),
-  sortOrder: z.number().int().min(0),
-}).refine(
-  (data) => !data.endDate || data.endDate >= data.startDate,
-  { message: '종료일은 시작일 이후여야 합니다', path: ['endDate'] },
-)
+export const profileEducationSchema = z
+  .object({
+    institutionName: z.string().min(1),
+    educationType: z.enum([
+      'vet_elementary',
+      'vet_intermediate',
+      'vet_college',
+      'higher_bachelor',
+      'higher_master',
+      'higher_doctorate',
+      'continuing_education',
+      'international_program',
+      'other',
+    ]),
+    field: z.string().optional(),
+    isGraduated: z.boolean(),
+    startDate: z.string().date(),
+    endDate: z.string().date().optional(),
+    sortOrder: z.number().int().min(0),
+  })
+  .refine((data) => !data.endDate || data.endDate >= data.startDate, {
+    message: '종료일은 시작일 이후여야 합니다',
+    path: ['endDate'],
+  });
 
 export const profileUrlSchema = z.object({
   label: z.string().min(1),
-  url: z.string().url().refine(
-    (val) => val.startsWith('http://') || val.startsWith('https://'),
-    { message: 'http 또는 https URL이어야 합니다' },
-  ),
+  url: z
+    .string()
+    .url()
+    .refine((val) => val.startsWith('http://') || val.startsWith('https://'), {
+      message: 'http 또는 https URL이어야 합니다',
+    }),
   sortOrder: z.number().int().min(0),
-})
+});
 
 export const profileSkillSchema = z.object({
   skillId: z.string().min(1),
-})
+});

--- a/stories/Configure.mdx
+++ b/stories/Configure.mdx
@@ -1,36 +1,38 @@
-import { Meta } from "@storybook/addon-docs/blocks";
-import Image from "next/image";
+import { Meta } from '@storybook/addon-docs/blocks';
+import Image from 'next/image';
 
-import Github from "./assets/github.svg";
-import Discord from "./assets/discord.svg";
-import Youtube from "./assets/youtube.svg";
-import Tutorials from "./assets/tutorials.svg";
-import Styling from "./assets/styling.png";
-import Context from "./assets/context.png";
-import Assets from "./assets/assets.png";
-import Docs from "./assets/docs.png";
-import Share from "./assets/share.png";
-import FigmaPlugin from "./assets/figma-plugin.png";
-import Testing from "./assets/testing.png";
-import Accessibility from "./assets/accessibility.png";
-import Theming from "./assets/theming.png";
-import AddonLibrary from "./assets/addon-library.png";
+import Github from './assets/github.svg';
+import Discord from './assets/discord.svg';
+import Youtube from './assets/youtube.svg';
+import Tutorials from './assets/tutorials.svg';
+import Styling from './assets/styling.png';
+import Context from './assets/context.png';
+import Assets from './assets/assets.png';
+import Docs from './assets/docs.png';
+import Share from './assets/share.png';
+import FigmaPlugin from './assets/figma-plugin.png';
+import Testing from './assets/testing.png';
+import Accessibility from './assets/accessibility.png';
+import Theming from './assets/theming.png';
+import AddonLibrary from './assets/addon-library.png';
 
-export const RightArrow = () => <svg 
-    viewBox="0 0 14 14" 
-    width="8px" 
-    height="14px" 
-    style={{ 
+export const RightArrow = () => (
+  <svg
+    viewBox="0 0 14 14"
+    width="8px"
+    height="14px"
+    style={{
       marginLeft: '4px',
       display: 'inline-block',
       shapeRendering: 'inherit',
       verticalAlign: 'middle',
       fill: 'currentColor',
-      'path fill': 'currentColor'
+      'path fill': 'currentColor',
     }}
->
-  <path d="m11.1 7.35-5.5 5.5a.5.5 0 0 1-.7-.7L10.04 7 4.9 1.85a.5.5 0 1 1 .7-.7l5.5 5.5c.2.2.2.5 0 .7Z" />
-</svg>
+  >
+    <path d="m11.1 7.35-5.5 5.5a.5.5 0 0 1-.7-.7L10.04 7 4.9 1.85a.5.5 0 1 1 .7-.7l5.5 5.5c.2.2.2.5 0 .7Z" />
+  </svg>
+);
 
 <Meta title="Configure your project" />
 
@@ -39,6 +41,7 @@ export const RightArrow = () => <svg
     # Configure your project
 
     Because Storybook works separately from your app, you'll need to configure it for your specific stack and setup. Below, explore guides for configuring Storybook with popular frameworks and tools. If you get stuck, learn how you can ask for help from our community.
+
   </div>
   <div className="sb-section">
     <div className="sb-section-item">
@@ -97,6 +100,7 @@ export const RightArrow = () => <svg
     # Do more with Storybook
 
     Now that you know the basics, let's explore other parts of Storybook that will improve your experience. This list is just to get you started. You can customise Storybook in many ways to fit your needs.
+
   </div>
 
   <div className="sb-section">
@@ -234,12 +238,12 @@ export const RightArrow = () => <svg
       >Star on GitHub<RightArrow /></a>
     </div>
     <div className="sb-section-item">
-      <Image 
+      <Image
         width={33}
         height={32}
         layout="fixed"
-        src={Discord} 
-        alt="Discord logo" 
+        src={Discord}
+        alt="Discord logo"
         className="sb-explore-image"
       />
       <div>
@@ -252,12 +256,12 @@ export const RightArrow = () => <svg
       </div>
     </div>
     <div className="sb-section-item">
-      <Image 
+      <Image
         width={32}
         height={32}
         layout="fixed"
-        src={Youtube} 
-        alt="Youtube logo" 
+        src={Youtube}
+        alt="Youtube logo"
         className="sb-explore-image"
       />
       <div>
@@ -270,12 +274,12 @@ export const RightArrow = () => <svg
       </div>
     </div>
     <div className="sb-section-item">
-      <Image 
+      <Image
         width={33}
         height={32}
         layout="fixed"
-        src={Tutorials} 
-        alt="A book" 
+        src={Tutorials}
+        alt="A book"
         className="sb-explore-image"
       />
       <p>Follow guided walkthroughs on for key workflows.</p>
@@ -285,6 +289,7 @@ export const RightArrow = () => <svg
           target="_blank"
         >Discover tutorials<RightArrow /></a>
     </div>
+
 </div>
 
 <style>


### PR DESCRIPTION
## Summary

- `lib/validations/profile.ts`: 프로필 관련 7개 Zod 스키마 (Public/Private/Language/Career/Education/Url/Skill)
- `lib/validations/application.ts`: 지원 스키마 (UUID 검증)
- `lib/validations/job-description.ts`: 채용공고 필터 스키마 (페이지네이션 기본값 포함)
- Career/Education 날짜 순서 정제 (endDate >= startDate)
- URL 스키마 http/https 제한 (`z.string().url()` + `.refine()`)

## Test plan

- [ ] `pnpm test __tests__/lib/validations/` — 32개 테스트 통과 확인
- [ ] `pnpm exec tsc --noEmit` — 타입 오류 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)