### PR TITLE
feat: Prompt 7 — 도메인 레이어 (Authorization + Errors)

### DIFF
--- a/__tests__/lib/domain/authorization.test.ts
+++ b/__tests__/lib/domain/authorization.test.ts
@@ -1,0 +1,64 @@
+import {
+  assertOwnership,
+  assertRole,
+  canViewCandidate,
+  assertCanViewCandidate,
+} from '@/lib/domain/authorization';
+import { DomainError } from '@/lib/domain/errors';
+
+describe('assertOwnership', () => {
+  it('ID 일치 시 통과', () => {
+    expect(() => assertOwnership('u1', 'u1')).not.toThrow();
+  });
+  it('ID 불일치 시 FORBIDDEN throw', () => {
+    expect(() => assertOwnership('u1', 'u2')).toThrow(DomainError);
+  });
+});
+
+describe('assertRole', () => {
+  it('허용된 역할이면 통과', () => {
+    expect(() => assertRole('recruiter', 'recruiter', 'admin')).not.toThrow();
+  });
+  it('불허 역할이면 FORBIDDEN throw', () => {
+    expect(() => assertRole('candidate', 'recruiter', 'admin')).toThrow(
+      DomainError
+    );
+  });
+});
+
+describe('canViewCandidate', () => {
+  it('체커가 true 반환 시 true', async () => {
+    const checker = async () => true;
+    expect(await canViewCandidate('c1', checker)).toBe(true);
+  });
+  it('체커가 false 반환 시 false', async () => {
+    const checker = async () => false;
+    expect(await canViewCandidate('c1', checker)).toBe(false);
+  });
+});
+
+describe('assertCanViewCandidate', () => {
+  const reachable = async () => true;
+  const unreachable = async () => false;
+
+  it('recruiter + 도달 가능 → 통과', async () => {
+    await expect(
+      assertCanViewCandidate('recruiter', 'c1', reachable)
+    ).resolves.not.toThrow();
+  });
+  it('admin + 도달 가능 → 통과', async () => {
+    await expect(
+      assertCanViewCandidate('admin', 'c1', reachable)
+    ).resolves.not.toThrow();
+  });
+  it('recruiter + 도달 불가 → FORBIDDEN throw', async () => {
+    await expect(
+      assertCanViewCandidate('recruiter', 'c1', unreachable)
+    ).rejects.toThrow(DomainError);
+  });
+  it('candidate 역할 → FORBIDDEN throw', async () => {
+    await expect(
+      assertCanViewCandidate('candidate', 'c1', reachable)
+    ).rejects.toThrow(DomainError);
+  });
+});

--- a/__tests__/lib/domain/errors.test.ts
+++ b/__tests__/lib/domain/errors.test.ts
@@ -1,0 +1,38 @@
+import {
+  DomainError,
+  notFound,
+  forbidden,
+  conflict,
+} from '@/lib/domain/errors';
+
+describe('DomainError', () => {
+  it('code와 message를 가진 인스턴스 생성', () => {
+    const err = new DomainError('NOT_FOUND', '찾을 수 없습니다');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.message).toBe('찾을 수 없습니다');
+  });
+});
+
+describe('notFound', () => {
+  it('NOT_FOUND 코드와 엔티티명 포함 메시지', () => {
+    const err = notFound('프로필');
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.message).toContain('프로필');
+  });
+});
+
+describe('forbidden', () => {
+  it('FORBIDDEN 코드', () => {
+    const err = forbidden();
+    expect(err.code).toBe('FORBIDDEN');
+  });
+});
+
+describe('conflict', () => {
+  it('CONFLICT 코드와 전달된 메시지', () => {
+    const err = conflict('이미 존재합니다');
+    expect(err.code).toBe('CONFLICT');
+    expect(err.message).toBe('이미 존재합니다');
+  });
+});

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -959,6 +959,18 @@ Task 4: __tests__/e2e/smoke.test.ts 통합 스모크 테스트.
 
 ---
 
+## 개발 워크플로우
+
+각 프롬프트 완료 후 표준 절차:
+
+1. **TDD**: 실패하는 테스트 먼저 작성 → 구현 → 테스트 통과 확인
+2. **커밋**: 논리적 단위로 자주 커밋 (`git commit`)
+3. **결과 문서화**: `docs/implementation-plan.md`의 해당 프롬프트에 `#### Prompt N 결과` 섹션 추가, 진행 상황 표 업데이트 (⬜ → ✅)
+4. **푸시**: `git push origin <feature-branch>`
+5. **PR 생성**: `gh pr create --base dev` — 제목/본문 한국어, base 브랜치는 `dev`
+
+---
+
 ## 보류 작업
 
 - [ ] README.md에 개발 기준 섹션 추가 (Task #1)

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -106,7 +106,7 @@ middleware.ts
 | 4   | Auth Client + Session       | Auth              | 클라이언트 SDK, getCurrentUser | ✅   |
 | 5   | Middleware + Signup Hooks   | Auth              | 라우트 보호, 유저 프로비저닝   | ✅   |
 | 6   | Zod Schemas                 | Validation        | 전체 도메인 입력 검증          | ✅   |
-| 7   | Authorization + Errors      | Domain            | 접근 제어, 도메인 에러         | ⬜   |
+| 7   | Authorization + Errors      | Domain            | 접근 제어, 도메인 에러         | ✅   |
 | 8   | Profile Use-Cases + Actions | Data              | 프로필 CRUD (15+ 액션)         | ⬜   |
 | 9   | Catalog + JD Queries        | Data              | 카탈로그/채용공고 조회         | ⬜   |
 | 10  | Application Management      | Data              | 지원, 철회, 채용담당자 조회    | ⬜   |
@@ -488,6 +488,23 @@ Task 3: __tests__/lib/domain/authorization.test.ts 테스트.
 
 검증: pnpm test 통과.
 ```
+
+#### Prompt 7 결과
+
+**상태**: ✅ 완료 (커밋: `da8baad`, PR #8)
+
+완료 항목:
+
+- `lib/domain/errors.ts`: `DomainError` 클래스 (`code` 속성, `Error` 확장). `notFound(entity)`, `forbidden()`, `conflict(message)` 팩토리 헬퍼.
+- `lib/domain/authorization.ts`: `assertOwnership`, `assertRole`, `canViewCandidate`, `assertCanViewCandidate` — 인프라 의존 없는 순수 도메인 함수. `ReachabilityChecker` 타입 export.
+- `__tests__/lib/domain/errors.test.ts`: 4개 테스트.
+- `__tests__/lib/domain/authorization.test.ts`: 10개 테스트. Prisma mock 불필요 — stub 함수 주입.
+
+계획 대비 변경 사항:
+
+- `canViewCandidate`의 Prisma 직접 의존 제거. `ReachabilityChecker` 타입을 매개변수로 받아 호출자가 주입하는 방식으로 변경. 도메인 레이어에 인프라 import 없음.
+- 계획에 없던 `__tests__/lib/domain/errors.test.ts` 추가 — TDD 원칙에 따라 DomainError + 팩토리 헬퍼 직접 테스트.
+- 테스트에서 Prisma mock 불필요 — 도달 가능성 체커를 `async () => true/false` stub으로 주입하여 순수 단위 테스트 달성.
 
 ---
 

--- a/lib/domain/authorization.ts
+++ b/lib/domain/authorization.ts
@@ -1,5 +1,8 @@
 import { forbidden } from '@/lib/domain/errors';
 
+/** 앱 내 사용자 역할 — 인프라(Prisma) 에 의존하지 않는 도메인 타입 */
+export type AppRole = 'candidate' | 'recruiter' | 'admin';
+
 /** 도달 가능성 체커 — 호출자가 Prisma 쿼리 등으로 구현하여 주입 */
 export type ReachabilityChecker = (candidateId: string) => Promise<boolean>;
 
@@ -10,7 +13,7 @@ export function assertOwnership(
   if (currentUserId !== resourceUserId) throw forbidden();
 }
 
-export function assertRole(currentRole: string, ...allowed: string[]): void {
+export function assertRole(currentRole: AppRole, ...allowed: AppRole[]): void {
   if (!allowed.includes(currentRole)) throw forbidden();
 }
 
@@ -22,7 +25,7 @@ export async function canViewCandidate(
 }
 
 export async function assertCanViewCandidate(
-  viewerRole: string,
+  viewerRole: AppRole,
   candidateId: string,
   hasApplications: ReachabilityChecker
 ): Promise<void> {

--- a/lib/domain/authorization.ts
+++ b/lib/domain/authorization.ts
@@ -1,0 +1,32 @@
+import { forbidden } from '@/lib/domain/errors';
+
+/** 도달 가능성 체커 — 호출자가 Prisma 쿼리 등으로 구현하여 주입 */
+export type ReachabilityChecker = (candidateId: string) => Promise<boolean>;
+
+export function assertOwnership(
+  currentUserId: string,
+  resourceUserId: string
+): void {
+  if (currentUserId !== resourceUserId) throw forbidden();
+}
+
+export function assertRole(currentRole: string, ...allowed: string[]): void {
+  if (!allowed.includes(currentRole)) throw forbidden();
+}
+
+export async function canViewCandidate(
+  candidateId: string,
+  hasApplications: ReachabilityChecker
+): Promise<boolean> {
+  return hasApplications(candidateId);
+}
+
+export async function assertCanViewCandidate(
+  viewerRole: string,
+  candidateId: string,
+  hasApplications: ReachabilityChecker
+): Promise<void> {
+  assertRole(viewerRole, 'recruiter', 'admin');
+  const reachable = await canViewCandidate(candidateId, hasApplications);
+  if (!reachable) throw forbidden();
+}

--- a/lib/domain/errors.ts
+++ b/lib/domain/errors.ts
@@ -1,0 +1,21 @@
+export class DomainError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'DomainError';
+    this.code = code;
+  }
+}
+
+export function notFound(entity: string): DomainError {
+  return new DomainError('NOT_FOUND', `${entity}을(를) 찾을 수 없습니다`);
+}
+
+export function forbidden(): DomainError {
+  return new DomainError('FORBIDDEN', '접근 권한이 없습니다');
+}
+
+export function conflict(message: string): DomainError {
+  return new DomainError('CONFLICT', message);
+}


### PR DESCRIPTION
## Summary
- `lib/domain/errors.ts`: `DomainError` 클래스 (`code` 속성), `notFound`/`forbidden`/`conflict` 팩토리 헬퍼
- `lib/domain/authorization.ts`: `assertOwnership`, `assertRole`, `canViewCandidate`, `assertCanViewCandidate` — 인프라 의존 없는 순수 도메인 함수
- 도달 가능성 체커를 `ReachabilityChecker` 타입으로 매개변수 주입 — Prisma 직접 import 제거

## Test plan
- [x] `__tests__/lib/domain/errors.test.ts` — 4개 테스트 (DomainError 인스턴스, 팩토리 3종)
- [x] `__tests__/lib/domain/authorization.test.ts` — 10개 테스트 (소유권, 역할, 도달 가능성, 복합 체크)
- [x] 14개 테스트 전체 통과
- [x] `tsc --noEmit` 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)