### PR TITLE
feat: 프로필 use-case 및 서버 액션 구현 (Prompt 8)

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "inputs": [],
+  "servers": {
+    "figma": {
+      "url": "https://mcp.figma.com/mcp",
+      "type": "http"
+    }
+  }
+}

--- a/__tests__/lib/actions/profile.test.ts
+++ b/__tests__/lib/actions/profile.test.ts
@@ -1,0 +1,279 @@
+import {
+  updateProfilePublic,
+  updateProfilePrivate,
+  addProfileCareer,
+  updateProfileCareer,
+  deleteProfileCareer,
+  addProfileSkill,
+  deleteProfileSkill,
+  getMyProfile,
+  getProfileForRecruiter,
+} from '@/lib/actions/profile';
+import { DomainError } from '@/lib/domain/errors';
+import * as profileUseCases from '@/lib/use-cases/profile';
+import * as authUtils from '@/lib/infrastructure/auth-utils';
+import * as domainAuth from '@/lib/domain/authorization';
+
+jest.mock('@/lib/use-cases/profile');
+jest.mock('@/lib/infrastructure/auth-utils', () => ({
+  requireUser: jest.fn(),
+  requireRole: jest.fn(),
+}));
+jest.mock('@/lib/domain/authorization', () => ({
+  ...jest.requireActual('@/lib/domain/authorization'),
+  assertCanViewCandidate: jest.fn(),
+}));
+jest.mock('@/lib/infrastructure/db', () => ({
+  prisma: {
+    apply: { findFirst: jest.fn() },
+  },
+}));
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+const mockUser = {
+  userId: 'user-1',
+  email: 'test@test.com',
+  role: 'candidate',
+  orgId: null,
+};
+const mockRecruiter = {
+  userId: 'rec-1',
+  email: 'rec@test.com',
+  role: 'recruiter',
+  orgId: 'org-1',
+};
+
+describe('updateProfilePublic', () => {
+  it('성공 → { success: true } 반환', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+    (
+      profileUseCases.updatePublicProfile as unknown as jest.Mock
+    ).mockResolvedValue(undefined);
+
+    const result = await updateProfilePublic({
+      firstName: '김',
+      lastName: '철수',
+    });
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it('Zod 검증 실패 → { error: ... } 반환', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+
+    const result = await updateProfilePublic({ firstName: '' });
+
+    expect(result).toEqual(
+      expect.objectContaining({ error: expect.any(String) })
+    );
+  });
+
+  it('DomainError → { error: message } 반환', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+    const domainErr = new DomainError('NOT_FOUND', '프로필을 찾을 수 없습니다');
+    (
+      profileUseCases.updatePublicProfile as unknown as jest.Mock
+    ).mockRejectedValue(domainErr);
+
+    const result = await updateProfilePublic({
+      firstName: '김',
+      lastName: '철수',
+    });
+
+    expect(result).toEqual({ error: '프로필을 찾을 수 없습니다' });
+  });
+
+  it('미인증 → 에러 재throw', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockRejectedValue(
+      new Error('Unauthorized')
+    );
+
+    await expect(
+      updateProfilePublic({ firstName: '김', lastName: '철수' })
+    ).rejects.toThrow('Unauthorized');
+  });
+});
+
+describe('updateProfilePrivate', () => {
+  it('성공 → { success: true } 반환', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+    (
+      profileUseCases.updatePrivateProfile as unknown as jest.Mock
+    ).mockResolvedValue(undefined);
+
+    const result = await updateProfilePrivate({ phoneNumber: '+84123456789' });
+
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('addProfileCareer', () => {
+  const validCareer = {
+    companyName: '(주)테스트',
+    positionTitle: '개발자',
+    jobId: 'job-1',
+    employmentType: 'full_time',
+    startDate: '2020-01-01',
+    endDate: '2023-12-31',
+    sortOrder: 0,
+  };
+
+  it('유효한 경력 → success', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+    (profileUseCases.addCareer as unknown as jest.Mock).mockResolvedValue({});
+
+    const result = await addProfileCareer(validCareer);
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it('종료일 < 시작일 → { error: ... }', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+
+    const result = await addProfileCareer({
+      ...validCareer,
+      endDate: '2019-12-31',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({ error: expect.any(String) })
+    );
+  });
+});
+
+describe('updateProfileCareer', () => {
+  it('존재하지 않는 경력 → { error: ... }', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+    const domainErr = new DomainError('NOT_FOUND', '경력을 찾을 수 없습니다');
+    (profileUseCases.updateCareer as unknown as jest.Mock).mockRejectedValue(
+      domainErr
+    );
+
+    const result = await updateProfileCareer('career-1', {
+      companyName: '회사',
+      positionTitle: '직위',
+      jobId: 'job-1',
+      employmentType: 'full_time',
+      startDate: '2020-01-01',
+      sortOrder: 0,
+    });
+
+    expect(result).toEqual({ error: '경력을 찾을 수 없습니다' });
+  });
+});
+
+describe('deleteProfileCareer', () => {
+  it('경력 삭제 성공', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+    (profileUseCases.deleteCareer as unknown as jest.Mock).mockResolvedValue(
+      undefined
+    );
+
+    const result = await deleteProfileCareer('career-1');
+
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('addProfileSkill', () => {
+  it('스킬 추가 성공', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+    (profileUseCases.addSkill as unknown as jest.Mock).mockResolvedValue(
+      undefined
+    );
+
+    const result = await addProfileSkill('typescript');
+
+    expect(result).toEqual({ success: true });
+  });
+
+  it('중복 스킬 → { error: ... }', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+    const domainErr = new DomainError('CONFLICT', '이미 추가된 스킬입니다');
+    (profileUseCases.addSkill as unknown as jest.Mock).mockRejectedValue(
+      domainErr
+    );
+
+    const result = await addProfileSkill('typescript');
+
+    expect(result).toEqual({ error: '이미 추가된 스킬입니다' });
+  });
+});
+
+describe('deleteProfileSkill', () => {
+  it('스킬 삭제 성공', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+    (profileUseCases.deleteSkill as unknown as jest.Mock).mockResolvedValue(
+      undefined
+    );
+
+    const result = await deleteProfileSkill('typescript');
+
+    expect(result).toEqual({ success: true });
+  });
+});
+
+describe('getMyProfile', () => {
+  it('내 프로필 반환', async () => {
+    const profileData = {
+      id: 'user-1',
+      profilePublic: { firstName: '김', lastName: '철수' },
+    };
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(mockUser);
+    (profileUseCases.getFullProfile as unknown as jest.Mock).mockResolvedValue(
+      profileData
+    );
+
+    const result = await getMyProfile();
+
+    expect(result).toEqual({ success: true, data: profileData });
+  });
+
+  it('미인증 → 에러 재throw', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockRejectedValue(
+      new Error('Unauthorized')
+    );
+
+    await expect(getMyProfile()).rejects.toThrow('Unauthorized');
+  });
+});
+
+describe('getProfileForRecruiter', () => {
+  it('채용담당자 후보자 프로필 조회 성공', async () => {
+    const profileData = {
+      id: 'candidate-1',
+      profilePublic: { firstName: '이', lastName: '영희' },
+    };
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(
+      mockRecruiter
+    );
+    (
+      domainAuth.assertCanViewCandidate as unknown as jest.Mock
+    ).mockResolvedValue(undefined);
+    (
+      profileUseCases.getProfileForViewer as unknown as jest.Mock
+    ).mockResolvedValue(profileData);
+
+    const result = await getProfileForRecruiter('candidate-1');
+
+    expect(result).toEqual({ success: true, data: profileData });
+  });
+
+  it('접근 권한 없음 → { error: ... }', async () => {
+    (authUtils.requireUser as unknown as jest.Mock).mockResolvedValue(
+      mockRecruiter
+    );
+    const domainErr = new DomainError('FORBIDDEN', '접근 권한이 없습니다');
+    (
+      domainAuth.assertCanViewCandidate as unknown as jest.Mock
+    ).mockRejectedValue(domainErr);
+
+    const result = await getProfileForRecruiter('candidate-1');
+
+    expect(result).toEqual({ error: '접근 권한이 없습니다' });
+  });
+});

--- a/__tests__/lib/use-cases/profile.test.ts
+++ b/__tests__/lib/use-cases/profile.test.ts
@@ -1,0 +1,386 @@
+import {
+  getFullProfile,
+  getProfileForViewer,
+  updatePublicProfile,
+  updatePrivateProfile,
+  addCareer,
+  updateCareer,
+  deleteCareer,
+  addEducation,
+  updateEducation,
+  deleteEducation,
+  addLanguage,
+  updateLanguage,
+  deleteLanguage,
+  addUrl,
+  updateUrl,
+  deleteUrl,
+  addSkill,
+  deleteSkill,
+} from '@/lib/use-cases/profile';
+import { DomainError } from '@/lib/domain/errors';
+import { prisma } from '@/lib/infrastructure/db';
+
+jest.mock('@/lib/infrastructure/db', () => ({
+  prisma: {
+    appUser: {
+      findUnique: jest.fn(),
+    },
+    profilesPublic: {
+      update: jest.fn(),
+    },
+    profilesPrivate: {
+      update: jest.fn(),
+    },
+    profileCareer: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    profileEducation: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    profileLanguage: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    profileUrl: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    profileSkill: {
+      create: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+  },
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+const mockUser = {
+  id: 'user-1',
+  profilePublic: { firstName: '홍', lastName: '길동', aboutMe: null },
+  profilePrivate: { phoneNumber: null },
+  careers: [],
+  educations: [],
+  languages: [],
+  urls: [],
+  profileSkills: [],
+  attachments: [],
+};
+
+describe('getFullProfile', () => {
+  it('유저 전체 프로필 반환', async () => {
+    (prisma.appUser.findUnique as unknown as jest.Mock).mockResolvedValue(
+      mockUser
+    );
+    const result = await getFullProfile('user-1');
+    expect(result).toEqual(mockUser);
+    expect(prisma.appUser.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'user-1' } })
+    );
+  });
+
+  it('유저 없음 → NOT_FOUND throw', async () => {
+    (prisma.appUser.findUnique as unknown as jest.Mock).mockResolvedValue(null);
+    await expect(getFullProfile('nonexistent')).rejects.toThrow(DomainError);
+  });
+});
+
+describe('getProfileForViewer', () => {
+  it('partial 모드: 공개 정보 반환', async () => {
+    (prisma.appUser.findUnique as unknown as jest.Mock).mockResolvedValue(
+      mockUser
+    );
+    const result = await getProfileForViewer('user-1', 'partial');
+    expect(result).toEqual(mockUser);
+  });
+
+  it('full 모드: 비공개 정보 포함 반환', async () => {
+    (prisma.appUser.findUnique as unknown as jest.Mock).mockResolvedValue(
+      mockUser
+    );
+    const result = await getProfileForViewer('user-1', 'full');
+    expect(result).toEqual(mockUser);
+  });
+
+  it('유저 없음 → NOT_FOUND throw', async () => {
+    (prisma.appUser.findUnique as unknown as jest.Mock).mockResolvedValue(null);
+    await expect(getProfileForViewer('nonexistent', 'partial')).rejects.toThrow(
+      DomainError
+    );
+  });
+});
+
+describe('updatePublicProfile', () => {
+  it('퍼블릭 프로필 업데이트 호출', async () => {
+    const data = { firstName: '김', lastName: '철수', aboutMe: '안녕' };
+    (prisma.profilesPublic.update as unknown as jest.Mock).mockResolvedValue(
+      data
+    );
+    await updatePublicProfile('user-1', data);
+    expect(prisma.profilesPublic.update).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      data,
+    });
+  });
+});
+
+describe('updatePrivateProfile', () => {
+  it('프라이빗 프로필 업데이트 호출', async () => {
+    const data = { phoneNumber: '+84123456789' };
+    (prisma.profilesPrivate.update as unknown as jest.Mock).mockResolvedValue(
+      data
+    );
+    await updatePrivateProfile('user-1', data);
+    expect(prisma.profilesPrivate.update).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      data,
+    });
+  });
+});
+
+const careerData = {
+  companyName: '(주)테스트',
+  positionTitle: '개발자',
+  jobId: 'job-1',
+  employmentType: 'full_time' as const,
+  startDate: '2020-01-01',
+  endDate: '2023-12-31',
+  description: '업무 설명',
+  sortOrder: 0,
+};
+
+describe('addCareer', () => {
+  it('경력 생성 호출', async () => {
+    const created = { id: 'career-1', userId: 'user-1', ...careerData };
+    (prisma.profileCareer.create as unknown as jest.Mock).mockResolvedValue(
+      created
+    );
+    const result = await addCareer('user-1', careerData);
+    expect(prisma.profileCareer.create).toHaveBeenCalledWith({
+      data: { ...careerData, userId: 'user-1' },
+    });
+    expect(result).toEqual(created);
+  });
+});
+
+describe('updateCareer', () => {
+  it('경력 찾아 업데이트', async () => {
+    const existing = { id: 'career-1', userId: 'user-1' };
+    (prisma.profileCareer.findFirst as unknown as jest.Mock).mockResolvedValue(
+      existing
+    );
+    (prisma.profileCareer.update as unknown as jest.Mock).mockResolvedValue({
+      ...existing,
+      ...careerData,
+    });
+    await updateCareer('user-1', 'career-1', careerData);
+    expect(prisma.profileCareer.update).toHaveBeenCalledWith({
+      where: { id: 'career-1' },
+      data: careerData,
+    });
+  });
+
+  it('경력 없음 → NOT_FOUND throw', async () => {
+    (prisma.profileCareer.findFirst as unknown as jest.Mock).mockResolvedValue(
+      null
+    );
+    await expect(
+      updateCareer('user-1', 'nonexistent', careerData)
+    ).rejects.toThrow(DomainError);
+  });
+});
+
+describe('deleteCareer', () => {
+  it('경력 찾아 삭제', async () => {
+    (prisma.profileCareer.findFirst as unknown as jest.Mock).mockResolvedValue({
+      id: 'career-1',
+      userId: 'user-1',
+    });
+    (prisma.profileCareer.delete as unknown as jest.Mock).mockResolvedValue({});
+    await deleteCareer('user-1', 'career-1');
+    expect(prisma.profileCareer.delete).toHaveBeenCalledWith({
+      where: { id: 'career-1' },
+    });
+  });
+
+  it('경력 없음 → NOT_FOUND throw', async () => {
+    (prisma.profileCareer.findFirst as unknown as jest.Mock).mockResolvedValue(
+      null
+    );
+    await expect(deleteCareer('user-1', 'nonexistent')).rejects.toThrow(
+      DomainError
+    );
+  });
+});
+
+const educationData = {
+  institutionName: '서울대학교',
+  educationType: 'higher_bachelor' as const,
+  field: '컴퓨터공학',
+  isGraduated: true,
+  startDate: '2016-03-01',
+  endDate: '2020-02-28',
+  sortOrder: 0,
+};
+
+describe('addEducation', () => {
+  it('학력 생성 호출', async () => {
+    const created = { id: 'edu-1', userId: 'user-1', ...educationData };
+    (prisma.profileEducation.create as unknown as jest.Mock).mockResolvedValue(
+      created
+    );
+    await addEducation('user-1', educationData);
+    expect(prisma.profileEducation.create).toHaveBeenCalledWith({
+      data: { ...educationData, userId: 'user-1' },
+    });
+  });
+});
+
+describe('updateEducation', () => {
+  it('학력 없음 → NOT_FOUND throw', async () => {
+    (
+      prisma.profileEducation.findFirst as unknown as jest.Mock
+    ).mockResolvedValue(null);
+    await expect(
+      updateEducation('user-1', 'nonexistent', educationData)
+    ).rejects.toThrow(DomainError);
+  });
+});
+
+describe('deleteEducation', () => {
+  it('학력 없음 → NOT_FOUND throw', async () => {
+    (
+      prisma.profileEducation.findFirst as unknown as jest.Mock
+    ).mockResolvedValue(null);
+    await expect(deleteEducation('user-1', 'nonexistent')).rejects.toThrow(
+      DomainError
+    );
+  });
+});
+
+const languageData = {
+  language: '한국어',
+  proficiency: 'native' as const,
+  sortOrder: 0,
+};
+
+describe('addLanguage', () => {
+  it('언어 생성 호출', async () => {
+    (prisma.profileLanguage.create as unknown as jest.Mock).mockResolvedValue({
+      id: 'lang-1',
+      userId: 'user-1',
+      ...languageData,
+    });
+    await addLanguage('user-1', languageData);
+    expect(prisma.profileLanguage.create).toHaveBeenCalledWith({
+      data: { ...languageData, userId: 'user-1' },
+    });
+  });
+});
+
+describe('updateLanguage', () => {
+  it('언어 없음 → NOT_FOUND throw', async () => {
+    (
+      prisma.profileLanguage.findFirst as unknown as jest.Mock
+    ).mockResolvedValue(null);
+    await expect(
+      updateLanguage('user-1', 'nonexistent', languageData)
+    ).rejects.toThrow(DomainError);
+  });
+});
+
+describe('deleteLanguage', () => {
+  it('언어 없음 → NOT_FOUND throw', async () => {
+    (
+      prisma.profileLanguage.findFirst as unknown as jest.Mock
+    ).mockResolvedValue(null);
+    await expect(deleteLanguage('user-1', 'nonexistent')).rejects.toThrow(
+      DomainError
+    );
+  });
+});
+
+const urlData = {
+  label: 'GitHub',
+  url: 'https://github.com/user',
+  sortOrder: 0,
+};
+
+describe('addUrl', () => {
+  it('URL 생성 호출', async () => {
+    (prisma.profileUrl.create as unknown as jest.Mock).mockResolvedValue({
+      id: 'url-1',
+      userId: 'user-1',
+      ...urlData,
+    });
+    await addUrl('user-1', urlData);
+    expect(prisma.profileUrl.create).toHaveBeenCalledWith({
+      data: { ...urlData, userId: 'user-1' },
+    });
+  });
+});
+
+describe('updateUrl', () => {
+  it('URL 없음 → NOT_FOUND throw', async () => {
+    (prisma.profileUrl.findFirst as unknown as jest.Mock).mockResolvedValue(
+      null
+    );
+    await expect(updateUrl('user-1', 'nonexistent', urlData)).rejects.toThrow(
+      DomainError
+    );
+  });
+});
+
+describe('deleteUrl', () => {
+  it('URL 없음 → NOT_FOUND throw', async () => {
+    (prisma.profileUrl.findFirst as unknown as jest.Mock).mockResolvedValue(
+      null
+    );
+    await expect(deleteUrl('user-1', 'nonexistent')).rejects.toThrow(
+      DomainError
+    );
+  });
+});
+
+describe('addSkill', () => {
+  it('스킬 생성 호출', async () => {
+    (prisma.profileSkill.create as unknown as jest.Mock).mockResolvedValue({
+      id: 'skill-1',
+      userId: 'user-1',
+      skillId: 'typescript',
+    });
+    await addSkill('user-1', 'typescript');
+    expect(prisma.profileSkill.create).toHaveBeenCalledWith({
+      data: { userId: 'user-1', skillId: 'typescript' },
+    });
+  });
+
+  it('중복 스킬 → CONFLICT throw', async () => {
+    (prisma.profileSkill.create as unknown as jest.Mock).mockRejectedValue({
+      code: 'P2002',
+    });
+    await expect(addSkill('user-1', 'typescript')).rejects.toThrow(DomainError);
+  });
+});
+
+describe('deleteSkill', () => {
+  it('스킬 삭제 호출 (deleteMany)', async () => {
+    (prisma.profileSkill.deleteMany as unknown as jest.Mock).mockResolvedValue({
+      count: 1,
+    });
+    await deleteSkill('user-1', 'typescript');
+    expect(prisma.profileSkill.deleteMany).toHaveBeenCalledWith({
+      where: { userId: 'user-1', skillId: 'typescript' },
+    });
+  });
+});

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -107,7 +107,7 @@ middleware.ts
 | 5   | Middleware + Signup Hooks   | Auth              | 라우트 보호, 유저 프로비저닝   | ✅   |
 | 6   | Zod Schemas                 | Validation        | 전체 도메인 입력 검증          | ✅   |
 | 7   | Authorization + Errors      | Domain            | 접근 제어, 도메인 에러         | ✅   |
-| 8   | Profile Use-Cases + Actions | Data              | 프로필 CRUD (15+ 액션)         | ⬜   |
+| 8   | Profile Use-Cases + Actions | Data              | 프로필 CRUD (15+ 액션)         | ✅   |
 | 9   | Catalog + JD Queries        | Data              | 카탈로그/채용공고 조회         | ⬜   |
 | 10  | Application Management      | Data              | 지원, 철회, 채용담당자 조회    | ⬜   |
 | 11  | Layout + Providers + Nav    | UI/Widget         | 프로바이더, 네비게이션 쉘      | ⬜   |
@@ -556,6 +556,22 @@ Task 3: 테스트 작성.
 
 검증: pnpm test 통과.
 ```
+
+#### Prompt 8 결과
+
+**상태**: ✅ 완료
+
+완료 항목:
+
+- `lib/use-cases/profile.ts`: 18개 함수. `getFullProfile`, `getProfileForViewer(mode: 'partial'|'full')`, `updatePublicProfile`, `updatePrivateProfile`, 경력/학력/언어/URL 각 add/update/delete (12개), `addSkill`, `deleteSkill`. update/delete는 `findFirst({ id, userId })`로 소유권 검사 후 처리. `addSkill`은 P2002 에러를 `conflict()` DomainError로 변환.
+- `lib/actions/profile.ts`: 18개 서버 액션. 공통 패턴: `requireUser` → Zod 검증 → use-case 호출 → `revalidatePath`. DomainError/ZodError → `{ error: string }`, 기타 에러는 재throw. `getProfileForRecruiter`는 `assertCanViewCandidate` + `ReachabilityChecker` 패턴 사용.
+- `__tests__/lib/use-cases/profile.test.ts`: 24개 테스트.
+- `__tests__/lib/actions/profile.test.ts`: 16개 테스트.
+
+계획 대비 변경 사항:
+
+- `jest.mock('@/lib/infrastructure/auth-utils')` 자동 모킹 시 better-auth ESM 로드 오류 발생 → 팩토리 함수 방식으로 변경: `jest.mock('@/lib/infrastructure/auth-utils', () => ({ requireUser: jest.fn(), requireRole: jest.fn() }))`. 기존 auth-utils.test.ts와 일관된 방식.
+- 테스트 106개 통과 (기존 66개 → +40개).
 
 ---
 

--- a/lib/actions/profile.ts
+++ b/lib/actions/profile.ts
@@ -1,0 +1,296 @@
+'use server';
+
+import { ZodError } from 'zod';
+import { revalidatePath } from 'next/cache';
+import { DomainError } from '@/lib/domain/errors';
+import {
+  assertCanViewCandidate,
+  type AppRole,
+  type ReachabilityChecker,
+} from '@/lib/domain/authorization';
+import { requireUser } from '@/lib/infrastructure/auth-utils';
+import { prisma } from '@/lib/infrastructure/db';
+import {
+  profilePublicSchema,
+  profilePrivateSchema,
+  profileCareerSchema,
+  profileEducationSchema,
+  profileLanguageSchema,
+  profileUrlSchema,
+} from '@/lib/validations/profile';
+import {
+  getFullProfile,
+  getProfileForViewer,
+  updatePublicProfile,
+  updatePrivateProfile,
+  addCareer,
+  updateCareer,
+  deleteCareer,
+  addEducation,
+  updateEducation,
+  deleteEducation,
+  addLanguage,
+  updateLanguage,
+  deleteLanguage,
+  addUrl,
+  updateUrl,
+  deleteUrl,
+  addSkill,
+  deleteSkill,
+} from '@/lib/use-cases/profile';
+
+type MutationResult = { success: true } | { error: string };
+type QueryResult<T> = { success: true; data: T } | { error: string };
+
+function handleError(e: unknown): { error: string } {
+  if (e instanceof DomainError) return { error: e.message };
+  if (e instanceof ZodError) return { error: '입력값이 유효하지 않습니다' };
+  throw e;
+}
+
+const PROFILE_PATH = '/dashboard/candidate/profile';
+
+export async function updateProfilePublic(
+  input: unknown
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    const data = profilePublicSchema.parse(input);
+    await updatePublicProfile(user.userId, data);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function updateProfilePrivate(
+  input: unknown
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    const data = profilePrivateSchema.parse(input);
+    await updatePrivateProfile(user.userId, data);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function addProfileCareer(
+  input: unknown
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    const data = profileCareerSchema.parse(input);
+    await addCareer(user.userId, data);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function updateProfileCareer(
+  id: string,
+  input: unknown
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    const data = profileCareerSchema.parse(input);
+    await updateCareer(user.userId, id, data);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function deleteProfileCareer(id: string): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    await deleteCareer(user.userId, id);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function addProfileEducation(
+  input: unknown
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    const data = profileEducationSchema.parse(input);
+    await addEducation(user.userId, data);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function updateProfileEducation(
+  id: string,
+  input: unknown
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    const data = profileEducationSchema.parse(input);
+    await updateEducation(user.userId, id, data);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function deleteProfileEducation(
+  id: string
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    await deleteEducation(user.userId, id);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function addProfileLanguage(
+  input: unknown
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    const data = profileLanguageSchema.parse(input);
+    await addLanguage(user.userId, data);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function updateProfileLanguage(
+  id: string,
+  input: unknown
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    const data = profileLanguageSchema.parse(input);
+    await updateLanguage(user.userId, id, data);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function deleteProfileLanguage(
+  id: string
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    await deleteLanguage(user.userId, id);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function addProfileUrl(input: unknown): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    const data = profileUrlSchema.parse(input);
+    await addUrl(user.userId, data);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function updateProfileUrl(
+  id: string,
+  input: unknown
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    const data = profileUrlSchema.parse(input);
+    await updateUrl(user.userId, id, data);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function deleteProfileUrl(id: string): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    await deleteUrl(user.userId, id);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function addProfileSkill(
+  skillId: string
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    await addSkill(user.userId, skillId);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function deleteProfileSkill(
+  skillId: string
+): Promise<MutationResult> {
+  try {
+    const user = await requireUser();
+    await deleteSkill(user.userId, skillId);
+    revalidatePath(PROFILE_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function getMyProfile(): Promise<
+  QueryResult<Awaited<ReturnType<typeof getFullProfile>>>
+> {
+  try {
+    const user = await requireUser();
+    const data = await getFullProfile(user.userId);
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function getProfileForRecruiter(
+  candidateId: string
+): Promise<QueryResult<Awaited<ReturnType<typeof getProfileForViewer>>>> {
+  try {
+    const user = await requireUser();
+    const checker: ReachabilityChecker = (cId) =>
+      prisma.apply
+        .findFirst({ where: { userId: cId } })
+        .then((r) => r !== null);
+    await assertCanViewCandidate(user.role as AppRole, candidateId, checker);
+    const data = await getProfileForViewer(candidateId, 'full');
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}

--- a/lib/use-cases/profile.ts
+++ b/lib/use-cases/profile.ts
@@ -1,0 +1,188 @@
+import { prisma } from '@/lib/infrastructure/db';
+import { notFound, conflict } from '@/lib/domain/errors';
+import type { z } from 'zod';
+import type {
+  profilePublicSchema,
+  profilePrivateSchema,
+  profileCareerSchema,
+  profileEducationSchema,
+  profileLanguageSchema,
+  profileUrlSchema,
+} from '@/lib/validations/profile';
+
+export async function getFullProfile(userId: string) {
+  const profile = await prisma.appUser.findUnique({
+    where: { id: userId },
+    include: {
+      profilePublic: true,
+      profilePrivate: true,
+      careers: { include: { job: true }, orderBy: { sortOrder: 'asc' } },
+      educations: { orderBy: { sortOrder: 'asc' } },
+      languages: { orderBy: { sortOrder: 'asc' } },
+      urls: { orderBy: { sortOrder: 'asc' } },
+      profileSkills: { include: { skill: true } },
+      attachments: true,
+    },
+  });
+  if (!profile) throw notFound('프로필');
+  return profile;
+}
+
+export async function getProfileForViewer(
+  candidateId: string,
+  mode: 'partial' | 'full'
+) {
+  const baseInclude = {
+    profilePublic: true,
+    careers: { include: { job: true }, orderBy: { sortOrder: 'asc' } },
+    educations: { orderBy: { sortOrder: 'asc' } },
+    languages: { orderBy: { sortOrder: 'asc' } },
+    urls: { orderBy: { sortOrder: 'asc' } },
+    profileSkills: { include: { skill: true } },
+  } as const;
+
+  const include =
+    mode === 'full'
+      ? { ...baseInclude, profilePrivate: true, attachments: true }
+      : baseInclude;
+
+  const profile = await prisma.appUser.findUnique({
+    where: { id: candidateId },
+    include,
+  });
+  if (!profile) throw notFound('프로필');
+  return profile;
+}
+
+export async function updatePublicProfile(
+  userId: string,
+  data: z.infer<typeof profilePublicSchema>
+) {
+  return prisma.profilesPublic.update({ where: { userId }, data });
+}
+
+export async function updatePrivateProfile(
+  userId: string,
+  data: z.infer<typeof profilePrivateSchema>
+) {
+  return prisma.profilesPrivate.update({ where: { userId }, data });
+}
+
+export async function addCareer(
+  userId: string,
+  data: z.infer<typeof profileCareerSchema>
+) {
+  return prisma.profileCareer.create({ data: { ...data, userId } });
+}
+
+export async function updateCareer(
+  userId: string,
+  id: string,
+  data: z.infer<typeof profileCareerSchema>
+) {
+  const existing = await prisma.profileCareer.findFirst({
+    where: { id, userId },
+  });
+  if (!existing) throw notFound('경력');
+  return prisma.profileCareer.update({ where: { id }, data });
+}
+
+export async function deleteCareer(userId: string, id: string) {
+  const existing = await prisma.profileCareer.findFirst({
+    where: { id, userId },
+  });
+  if (!existing) throw notFound('경력');
+  return prisma.profileCareer.delete({ where: { id } });
+}
+
+export async function addEducation(
+  userId: string,
+  data: z.infer<typeof profileEducationSchema>
+) {
+  return prisma.profileEducation.create({ data: { ...data, userId } });
+}
+
+export async function updateEducation(
+  userId: string,
+  id: string,
+  data: z.infer<typeof profileEducationSchema>
+) {
+  const existing = await prisma.profileEducation.findFirst({
+    where: { id, userId },
+  });
+  if (!existing) throw notFound('학력');
+  return prisma.profileEducation.update({ where: { id }, data });
+}
+
+export async function deleteEducation(userId: string, id: string) {
+  const existing = await prisma.profileEducation.findFirst({
+    where: { id, userId },
+  });
+  if (!existing) throw notFound('학력');
+  return prisma.profileEducation.delete({ where: { id } });
+}
+
+export async function addLanguage(
+  userId: string,
+  data: z.infer<typeof profileLanguageSchema>
+) {
+  return prisma.profileLanguage.create({ data: { ...data, userId } });
+}
+
+export async function updateLanguage(
+  userId: string,
+  id: string,
+  data: z.infer<typeof profileLanguageSchema>
+) {
+  const existing = await prisma.profileLanguage.findFirst({
+    where: { id, userId },
+  });
+  if (!existing) throw notFound('언어');
+  return prisma.profileLanguage.update({ where: { id }, data });
+}
+
+export async function deleteLanguage(userId: string, id: string) {
+  const existing = await prisma.profileLanguage.findFirst({
+    where: { id, userId },
+  });
+  if (!existing) throw notFound('언어');
+  return prisma.profileLanguage.delete({ where: { id } });
+}
+
+export async function addUrl(
+  userId: string,
+  data: z.infer<typeof profileUrlSchema>
+) {
+  return prisma.profileUrl.create({ data: { ...data, userId } });
+}
+
+export async function updateUrl(
+  userId: string,
+  id: string,
+  data: z.infer<typeof profileUrlSchema>
+) {
+  const existing = await prisma.profileUrl.findFirst({ where: { id, userId } });
+  if (!existing) throw notFound('URL');
+  return prisma.profileUrl.update({ where: { id }, data });
+}
+
+export async function deleteUrl(userId: string, id: string) {
+  const existing = await prisma.profileUrl.findFirst({ where: { id, userId } });
+  if (!existing) throw notFound('URL');
+  return prisma.profileUrl.delete({ where: { id } });
+}
+
+export async function addSkill(userId: string, skillId: string) {
+  try {
+    return await prisma.profileSkill.create({ data: { userId, skillId } });
+  } catch (e) {
+    if ((e as { code?: string }).code === 'P2002') {
+      throw conflict('이미 추가된 스킬입니다');
+    }
+    throw e;
+  }
+}
+
+export async function deleteSkill(userId: string, skillId: string) {
+  return prisma.profileSkill.deleteMany({ where: { userId, skillId } });
+}


### PR DESCRIPTION
## 요약

- `lib/use-cases/profile.ts`: 18개 함수 — 프로필 CRUD (공개/비공개 프로필, 경력/학력/언어/URL/스킬)
- `lib/actions/profile.ts`: 18개 서버 액션 어댑터 — `requireUser` → Zod 검증 → use-case 호출 → `revalidatePath`
- `getProfileForRecruiter`: `assertCanViewCandidate` + `ReachabilityChecker` DI 패턴으로 채용담당자 접근 제어
- 테스트 40개 추가 (use-case 24개, action 16개) → 총 106개 통과

## Clean Architecture 패턴

```
lib/actions/profile.ts  →  requireUser / Zod 검증  →  lib/use-cases/profile.ts  →  Prisma
```

- use-case 레이어: 소유권 검사는 `findFirst({ id, userId })` null 체크로 처리
- action 레이어: `DomainError` / `ZodError` → `{ error: string }`, 기타 에러는 재throw

## 테스트 계획

- [x] `pnpm jest` → 106개 전체 통과
- [x] 기존 66개 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)