### PR TITLE
feat: Prompt 9 — 카탈로그 + 채용공고 쿼리

### DIFF
--- a/__tests__/lib/actions/catalog.test.ts
+++ b/__tests__/lib/actions/catalog.test.ts
@@ -1,0 +1,89 @@
+import {
+  getJobFamilies,
+  getJobs,
+  searchSkills,
+  getSkillById,
+} from '@/lib/actions/catalog';
+import { DomainError } from '@/lib/domain/errors';
+import * as catalogUC from '@/lib/use-cases/catalog';
+
+jest.mock('@/lib/use-cases/catalog', () => ({
+  getJobFamilies: jest.fn(),
+  getJobs: jest.fn(),
+  searchSkills: jest.fn(),
+  getSkillById: jest.fn(),
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('getJobFamilies', () => {
+  it('성공 → { success: true, data }', async () => {
+    const mockData = [{ id: 'engineering', displayNameEn: 'Engineering' }];
+    (catalogUC.getJobFamilies as unknown as jest.Mock).mockResolvedValue(
+      mockData
+    );
+
+    const result = await getJobFamilies();
+
+    expect(result).toEqual({ success: true, data: mockData });
+    expect(catalogUC.getJobFamilies).toHaveBeenCalled();
+  });
+});
+
+describe('getJobs', () => {
+  it('familyId 전달 → use-case에 전달됨', async () => {
+    const mockData = [{ id: 'frontend', displayNameEn: 'Frontend' }];
+    (catalogUC.getJobs as unknown as jest.Mock).mockResolvedValue(mockData);
+
+    const result = await getJobs('engineering');
+
+    expect(result).toEqual({ success: true, data: mockData });
+    expect(catalogUC.getJobs).toHaveBeenCalledWith('engineering');
+  });
+
+  it('familyId 없음 → undefined 전달', async () => {
+    (catalogUC.getJobs as unknown as jest.Mock).mockResolvedValue([]);
+
+    await getJobs();
+
+    expect(catalogUC.getJobs).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe('searchSkills', () => {
+  it('쿼리 전달 → 결과 반환', async () => {
+    const mockData = [{ id: 'typescript', displayNameEn: 'TypeScript' }];
+    (catalogUC.searchSkills as unknown as jest.Mock).mockResolvedValue(
+      mockData
+    );
+
+    const result = await searchSkills('type');
+
+    expect(result).toEqual({ success: true, data: mockData });
+    expect(catalogUC.searchSkills).toHaveBeenCalledWith('type');
+  });
+});
+
+describe('getSkillById', () => {
+  it('스킬 존재 → { success: true, data }', async () => {
+    const mockSkill = { id: 'typescript', displayNameEn: 'TypeScript' };
+    (catalogUC.getSkillById as unknown as jest.Mock).mockResolvedValue(
+      mockSkill
+    );
+
+    const result = await getSkillById('typescript');
+
+    expect(result).toEqual({ success: true, data: mockSkill });
+  });
+
+  it('DomainError → { error: message }', async () => {
+    const domainErr = new DomainError('NOT_FOUND', '스킬을 찾을 수 없습니다');
+    (catalogUC.getSkillById as unknown as jest.Mock).mockRejectedValue(
+      domainErr
+    );
+
+    const result = await getSkillById('nonexistent');
+
+    expect(result).toEqual({ error: '스킬을 찾을 수 없습니다' });
+  });
+});

--- a/__tests__/lib/use-cases/catalog.test.ts
+++ b/__tests__/lib/use-cases/catalog.test.ts
@@ -1,0 +1,135 @@
+import {
+  getJobFamilies,
+  getJobs,
+  searchSkills,
+  getSkillById,
+} from '@/lib/use-cases/catalog';
+import { prisma } from '@/lib/infrastructure/db';
+
+jest.mock('@/lib/infrastructure/db', () => ({
+  prisma: {
+    jobFamily: { findMany: jest.fn() },
+    job: { findMany: jest.fn() },
+    skill: { findMany: jest.fn(), findUnique: jest.fn() },
+  },
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('getJobFamilies', () => {
+  it('패밀리 + 직무 목록 반환', async () => {
+    const mockFamilies = [
+      {
+        id: 'engineering',
+        displayNameEn: 'Engineering',
+        sortOrder: 0,
+        jobs: [{ id: 'frontend', displayNameEn: 'Frontend', sortOrder: 0 }],
+      },
+    ];
+    (prisma.jobFamily.findMany as unknown as jest.Mock).mockResolvedValue(
+      mockFamilies
+    );
+
+    const result = await getJobFamilies();
+
+    expect(result).toEqual(mockFamilies);
+    expect(prisma.jobFamily.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: expect.objectContaining({ jobs: expect.any(Object) }),
+        orderBy: { sortOrder: 'asc' },
+      })
+    );
+  });
+});
+
+describe('getJobs', () => {
+  it('familyId 없음 → where 조건 없이 전체 조회', async () => {
+    const mockJobs = [{ id: 'frontend', displayNameEn: 'Frontend' }];
+    (prisma.job.findMany as unknown as jest.Mock).mockResolvedValue(mockJobs);
+
+    const result = await getJobs();
+
+    expect(result).toEqual(mockJobs);
+    expect(prisma.job.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: undefined })
+    );
+  });
+
+  it('familyId 있음 → jobFamilyId 필터 적용', async () => {
+    const mockJobs = [{ id: 'frontend', displayNameEn: 'Frontend' }];
+    (prisma.job.findMany as unknown as jest.Mock).mockResolvedValue(mockJobs);
+
+    await getJobs('engineering');
+
+    expect(prisma.job.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { jobFamilyId: 'engineering' } })
+    );
+  });
+});
+
+describe('searchSkills', () => {
+  it('쿼리로 스킬 검색 — ILIKE + 최대 20개', async () => {
+    const mockSkills = [{ id: 'typescript', displayNameEn: 'TypeScript' }];
+    (prisma.skill.findMany as unknown as jest.Mock).mockResolvedValue(
+      mockSkills
+    );
+
+    const result = await searchSkills('type');
+
+    expect(result).toEqual(mockSkills);
+    expect(prisma.skill.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          OR: [
+            {
+              displayNameEn: {
+                contains: 'type',
+                mode: 'insensitive',
+              },
+            },
+            {
+              aliases: {
+                some: {
+                  aliasNormalized: {
+                    contains: 'type',
+                    mode: 'insensitive',
+                  },
+                },
+              },
+            },
+          ],
+        },
+        take: 20,
+      })
+    );
+  });
+});
+
+describe('getSkillById', () => {
+  it('스킬 + aliases 반환', async () => {
+    const mockSkill = {
+      id: 'typescript',
+      displayNameEn: 'TypeScript',
+      aliases: [{ id: 'alias-1', alias: 'ts', aliasNormalized: 'ts' }],
+    };
+    (prisma.skill.findUnique as unknown as jest.Mock).mockResolvedValue(
+      mockSkill
+    );
+
+    const result = await getSkillById('typescript');
+
+    expect(result).toEqual(mockSkill);
+    expect(prisma.skill.findUnique).toHaveBeenCalledWith({
+      where: { id: 'typescript' },
+      include: { aliases: true },
+    });
+  });
+
+  it('스킬 없음 → null 반환 (throw 없음)', async () => {
+    (prisma.skill.findUnique as unknown as jest.Mock).mockResolvedValue(null);
+
+    const result = await getSkillById('nonexistent');
+
+    expect(result).toBeNull();
+  });
+});

--- a/__tests__/lib/use-cases/jd-queries.test.ts
+++ b/__tests__/lib/use-cases/jd-queries.test.ts
@@ -1,0 +1,139 @@
+import {
+  getJobDescriptions,
+  getJobDescriptionById,
+} from '@/lib/use-cases/jd-queries';
+import { DomainError } from '@/lib/domain/errors';
+import { prisma } from '@/lib/infrastructure/db';
+
+jest.mock('@/lib/infrastructure/db', () => ({
+  prisma: {
+    jobDescription: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+const mockJd = {
+  id: 'jd-1',
+  title: '프론트엔드 개발자',
+  employmentType: 'full_time',
+  workArrangement: 'remote',
+  job: {
+    id: 'frontend',
+    displayNameEn: 'Frontend',
+    family: { id: 'engineering' },
+  },
+  skills: [{ skill: { id: 'typescript', displayNameEn: 'TypeScript' } }],
+  org: { id: 'org-1', name: 'Vridge' },
+};
+
+describe('getJobDescriptions', () => {
+  beforeEach(() => {
+    (prisma.jobDescription.findMany as unknown as jest.Mock).mockResolvedValue([
+      mockJd,
+    ]);
+    (prisma.jobDescription.count as unknown as jest.Mock).mockResolvedValue(1);
+  });
+
+  it('기본 필터 없음 — 전체 목록 반환', async () => {
+    const result = await getJobDescriptions({
+      page: 1,
+      pageSize: 20,
+    });
+
+    expect(result).toEqual({
+      items: [mockJd],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    });
+    expect(prisma.jobDescription.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {},
+        skip: 0,
+        take: 20,
+        orderBy: { createdAt: 'desc' },
+      })
+    );
+  });
+
+  it('필터 적용 — where 조건 포함', async () => {
+    await getJobDescriptions({
+      jobId: 'frontend',
+      employmentType: 'full_time',
+      workArrangement: 'remote',
+      page: 1,
+      pageSize: 20,
+    });
+
+    expect(prisma.jobDescription.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          jobId: 'frontend',
+          employmentType: 'full_time',
+          workArrangement: 'remote',
+        },
+      })
+    );
+  });
+
+  it('미정의 필터는 where에 포함되지 않음', async () => {
+    await getJobDescriptions({
+      jobId: 'frontend',
+      page: 1,
+      pageSize: 20,
+    });
+
+    const callArg = (prisma.jobDescription.findMany as unknown as jest.Mock)
+      .mock.calls[0][0];
+    expect(callArg.where).not.toHaveProperty('employmentType');
+    expect(callArg.where).not.toHaveProperty('workArrangement');
+  });
+
+  it('page 2 — skip: pageSize', async () => {
+    await getJobDescriptions({ page: 2, pageSize: 10 });
+
+    expect(prisma.jobDescription.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 10, take: 10 })
+    );
+  });
+
+  it('{ items, total, page, pageSize } 형태 반환', async () => {
+    (prisma.jobDescription.count as unknown as jest.Mock).mockResolvedValue(42);
+
+    const result = await getJobDescriptions({ page: 3, pageSize: 5 });
+
+    expect(result.total).toBe(42);
+    expect(result.page).toBe(3);
+    expect(result.pageSize).toBe(5);
+  });
+});
+
+describe('getJobDescriptionById', () => {
+  it('JD 반환', async () => {
+    (
+      prisma.jobDescription.findUnique as unknown as jest.Mock
+    ).mockResolvedValue(mockJd);
+
+    const result = await getJobDescriptionById('jd-1');
+
+    expect(result).toEqual(mockJd);
+    expect(prisma.jobDescription.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'jd-1' } })
+    );
+  });
+
+  it('JD 없음 → DomainError throw', async () => {
+    (
+      prisma.jobDescription.findUnique as unknown as jest.Mock
+    ).mockResolvedValue(null);
+
+    await expect(getJobDescriptionById('nonexistent')).rejects.toThrow(
+      DomainError
+    );
+  });
+});

--- a/lib/actions/catalog.ts
+++ b/lib/actions/catalog.ts
@@ -1,0 +1,55 @@
+'use server';
+
+import { DomainError } from '@/lib/domain/errors';
+import * as catalogUC from '@/lib/use-cases/catalog';
+
+type QueryResult<T> = { success: true; data: T } | { error: string };
+
+function handleError(e: unknown): { error: string } {
+  if (e instanceof DomainError) return { error: e.message };
+  throw e;
+}
+
+export async function getJobFamilies(): Promise<
+  QueryResult<Awaited<ReturnType<typeof catalogUC.getJobFamilies>>>
+> {
+  try {
+    const data = await catalogUC.getJobFamilies();
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function getJobs(
+  familyId?: string
+): Promise<QueryResult<Awaited<ReturnType<typeof catalogUC.getJobs>>>> {
+  try {
+    const data = await catalogUC.getJobs(familyId);
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function searchSkills(
+  query: string
+): Promise<QueryResult<Awaited<ReturnType<typeof catalogUC.searchSkills>>>> {
+  try {
+    const data = await catalogUC.searchSkills(query);
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function getSkillById(
+  id: string
+): Promise<QueryResult<Awaited<ReturnType<typeof catalogUC.getSkillById>>>> {
+  try {
+    const data = await catalogUC.getSkillById(id);
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}

--- a/lib/actions/jd-queries.ts
+++ b/lib/actions/jd-queries.ts
@@ -1,0 +1,40 @@
+'use server';
+
+import { ZodError } from 'zod';
+import { DomainError } from '@/lib/domain/errors';
+import { jobDescriptionFilterSchema } from '@/lib/validations/job-description';
+import {
+  getJobDescriptions as ucGetJobDescriptions,
+  getJobDescriptionById as ucGetJobDescriptionById,
+} from '@/lib/use-cases/jd-queries';
+
+type QueryResult<T> = { success: true; data: T } | { error: string };
+
+function handleError(e: unknown): { error: string } {
+  if (e instanceof DomainError) return { error: e.message };
+  if (e instanceof ZodError) return { error: '필터 값이 유효하지 않습니다' };
+  throw e;
+}
+
+export async function getJobDescriptions(
+  input: unknown
+): Promise<QueryResult<Awaited<ReturnType<typeof ucGetJobDescriptions>>>> {
+  try {
+    const filters = jobDescriptionFilterSchema.parse(input);
+    const data = await ucGetJobDescriptions(filters);
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function getJobDescriptionById(
+  id: string
+): Promise<QueryResult<Awaited<ReturnType<typeof ucGetJobDescriptionById>>>> {
+  try {
+    const data = await ucGetJobDescriptionById(id);
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}

--- a/lib/use-cases/catalog.ts
+++ b/lib/use-cases/catalog.ts
@@ -1,0 +1,38 @@
+import { prisma } from '@/lib/infrastructure/db';
+
+export async function getJobFamilies() {
+  return prisma.jobFamily.findMany({
+    include: { jobs: { orderBy: { sortOrder: 'asc' } } },
+    orderBy: { sortOrder: 'asc' },
+  });
+}
+
+export async function getJobs(familyId?: string) {
+  return prisma.job.findMany({
+    where: familyId ? { jobFamilyId: familyId } : undefined,
+    orderBy: { sortOrder: 'asc' },
+  });
+}
+
+export async function searchSkills(query: string) {
+  return prisma.skill.findMany({
+    where: {
+      OR: [
+        { displayNameEn: { contains: query, mode: 'insensitive' } },
+        {
+          aliases: {
+            some: { aliasNormalized: { contains: query, mode: 'insensitive' } },
+          },
+        },
+      ],
+    },
+    take: 20,
+  });
+}
+
+export async function getSkillById(id: string) {
+  return prisma.skill.findUnique({
+    where: { id },
+    include: { aliases: true },
+  });
+}

--- a/lib/use-cases/jd-queries.ts
+++ b/lib/use-cases/jd-queries.ts
@@ -1,0 +1,44 @@
+import { prisma } from '@/lib/infrastructure/db';
+import { notFound } from '@/lib/domain/errors';
+import type { z } from 'zod';
+import type { jobDescriptionFilterSchema } from '@/lib/validations/job-description';
+
+const JD_INCLUDE = {
+  job: { include: { family: true } },
+  skills: { include: { skill: true } },
+  org: true,
+} as const;
+
+export async function getJobDescriptions(
+  filters: z.infer<typeof jobDescriptionFilterSchema>
+) {
+  const { jobId, employmentType, workArrangement, page, pageSize } = filters;
+
+  const where = {
+    ...(jobId !== undefined ? { jobId } : {}),
+    ...(employmentType !== undefined ? { employmentType } : {}),
+    ...(workArrangement !== undefined ? { workArrangement } : {}),
+  };
+
+  const [items, total] = await Promise.all([
+    prisma.jobDescription.findMany({
+      where,
+      include: JD_INCLUDE,
+      orderBy: { createdAt: 'desc' },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    }),
+    prisma.jobDescription.count({ where }),
+  ]);
+
+  return { items, total, page, pageSize };
+}
+
+export async function getJobDescriptionById(id: string) {
+  const jd = await prisma.jobDescription.findUnique({
+    where: { id },
+    include: JD_INCLUDE,
+  });
+  if (!jd) throw notFound('채용공고');
+  return jd;
+}


### PR DESCRIPTION
## 요약

- `lib/use-cases/catalog.ts`: `getJobFamilies`, `getJobs(familyId?)`, `searchSkills(query)` (ILIKE), `getSkillById(id)`
- `lib/use-cases/jd-queries.ts`: `getJobDescriptions(filters)` (페이지네이션 + 필터), `getJobDescriptionById(id)` (없으면 NOT_FOUND)
- `lib/actions/catalog.ts`: 인증 없는 공개 읽기 서버 액션 래퍼
- `lib/actions/jd-queries.ts`: Zod 필터 검증 포함 서버 액션 래퍼
- 테스트 24개 추가 → 총 130개

## 테스트 계획

- [x] `pnpm jest` — 130개 통과 확인
- [x] 카탈로그 use-case: `getJobFamilies`, `getJobs` (familyId 유무), `searchSkills` (ILIKE + take:20), `getSkillById` (found/null)
- [x] JD 쿼리 use-case: 필터 적용, 미정의 필터 제외, 페이지네이션 skip/take, `{ items, total, page, pageSize }` 반환 형태, NOT_FOUND throw
- [x] 카탈로그 액션: use-case 호출 전달, DomainError → `{ error }`
- [x] JD 쿼리 액션: 유효/무효 입력, NOT_FOUND → `{ error }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)