### PR TITLE
feat(applications): 지원 관리 use-case 및 서버 액션 구현 (Prompt 10)

### DIFF
--- a/__tests__/lib/actions/applications.test.ts
+++ b/__tests__/lib/actions/applications.test.ts
@@ -1,0 +1,156 @@
+import {
+  createApply,
+  withdrawApply,
+  getMyApplications,
+  getApplicationsForJd,
+} from '@/lib/actions/applications';
+import { DomainError } from '@/lib/domain/errors';
+import * as applicationsUC from '@/lib/use-cases/applications';
+import * as authUtils from '@/lib/infrastructure/auth-utils';
+
+jest.mock('@/lib/use-cases/applications', () => ({
+  createApplication: jest.fn(),
+  withdrawApplication: jest.fn(),
+  getUserApplications: jest.fn(),
+  getApplicationsForJd: jest.fn(),
+  getApplicantStats: jest.fn(),
+}));
+jest.mock('@/lib/infrastructure/auth-utils', () => ({
+  requireUser: jest.fn(),
+  requireRole: jest.fn(),
+}));
+jest.mock('next/cache', () => ({ revalidatePath: jest.fn() }));
+
+beforeEach(() => jest.clearAllMocks());
+
+const mockCandidate = {
+  userId: 'user-1',
+  email: 'user@test.com',
+  role: 'candidate',
+  orgId: null,
+};
+const mockRecruiter = {
+  userId: 'rec-1',
+  email: 'rec@test.com',
+  role: 'recruiter',
+  orgId: 'org-1',
+};
+
+describe('createApply', () => {
+  it('정상 지원 → { success: true }', async () => {
+    (authUtils.requireRole as unknown as jest.Mock).mockResolvedValue(
+      mockCandidate
+    );
+    (
+      applicationsUC.createApplication as unknown as jest.Mock
+    ).mockResolvedValue({
+      id: 'apply-1',
+    });
+
+    const result = await createApply({
+      jdId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+
+    expect(result).toEqual({ success: true });
+    expect(applicationsUC.createApplication).toHaveBeenCalledWith(
+      'user-1',
+      '123e4567-e89b-12d3-a456-426614174000'
+    );
+  });
+
+  it('유효하지 않은 입력 (UUID 아닌 jdId) → { error: ... }', async () => {
+    (authUtils.requireRole as unknown as jest.Mock).mockResolvedValue(
+      mockCandidate
+    );
+
+    const result = await createApply({ jdId: 'not-a-uuid' });
+
+    expect(result).toEqual(
+      expect.objectContaining({ error: expect.any(String) })
+    );
+    expect(applicationsUC.createApplication).not.toHaveBeenCalled();
+  });
+
+  it('CONFLICT → { error: message }', async () => {
+    (authUtils.requireRole as unknown as jest.Mock).mockResolvedValue(
+      mockCandidate
+    );
+    const err = new DomainError('CONFLICT', '이미 지원한 채용공고입니다');
+    (
+      applicationsUC.createApplication as unknown as jest.Mock
+    ).mockRejectedValue(err);
+
+    const result = await createApply({
+      jdId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+
+    expect(result).toEqual({ error: '이미 지원한 채용공고입니다' });
+  });
+});
+
+describe('withdrawApply', () => {
+  it('정상 철회 → { success: true }', async () => {
+    (authUtils.requireRole as unknown as jest.Mock).mockResolvedValue(
+      mockCandidate
+    );
+    (
+      applicationsUC.withdrawApplication as unknown as jest.Mock
+    ).mockResolvedValue(undefined);
+
+    const result = await withdrawApply('apply-1');
+
+    expect(result).toEqual({ success: true });
+    expect(applicationsUC.withdrawApplication).toHaveBeenCalledWith(
+      'user-1',
+      'apply-1'
+    );
+  });
+
+  it('FORBIDDEN → { error: message }', async () => {
+    (authUtils.requireRole as unknown as jest.Mock).mockResolvedValue(
+      mockCandidate
+    );
+    const err = new DomainError('FORBIDDEN', '접근 권한이 없습니다');
+    (
+      applicationsUC.withdrawApplication as unknown as jest.Mock
+    ).mockRejectedValue(err);
+
+    const result = await withdrawApply('apply-1');
+
+    expect(result).toEqual({ error: '접근 권한이 없습니다' });
+  });
+});
+
+describe('getMyApplications', () => {
+  it('내 지원 목록 반환', async () => {
+    const data = [{ id: 'apply-1', status: 'applied' }];
+    (authUtils.requireRole as unknown as jest.Mock).mockResolvedValue(
+      mockCandidate
+    );
+    (
+      applicationsUC.getUserApplications as unknown as jest.Mock
+    ).mockResolvedValue(data);
+
+    const result = await getMyApplications();
+
+    expect(result).toEqual({ success: true, data });
+    expect(applicationsUC.getUserApplications).toHaveBeenCalledWith('user-1');
+  });
+});
+
+describe('getApplicationsForJd', () => {
+  it('채용담당자 — JD 지원 목록 반환', async () => {
+    const data = [{ id: 'apply-1', user: { profilePublic: {} } }];
+    (authUtils.requireRole as unknown as jest.Mock).mockResolvedValue(
+      mockRecruiter
+    );
+    (
+      applicationsUC.getApplicationsForJd as unknown as jest.Mock
+    ).mockResolvedValue(data);
+
+    const result = await getApplicationsForJd('jd-1');
+
+    expect(result).toEqual({ success: true, data });
+    expect(applicationsUC.getApplicationsForJd).toHaveBeenCalledWith('jd-1');
+  });
+});

--- a/__tests__/lib/use-cases/applications.test.ts
+++ b/__tests__/lib/use-cases/applications.test.ts
@@ -1,0 +1,189 @@
+import {
+  createApplication,
+  withdrawApplication,
+  getUserApplications,
+  getApplicationsForJd,
+  getApplicantStats,
+} from '@/lib/use-cases/applications';
+import { DomainError } from '@/lib/domain/errors';
+import { prisma } from '@/lib/infrastructure/db';
+
+jest.mock('@/lib/infrastructure/db', () => ({
+  prisma: {
+    apply: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+      groupBy: jest.fn(),
+    },
+    jobDescription: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+const userId = 'user-1';
+const jdId = 'jd-1';
+const applyId = 'apply-1';
+
+const mockApply = {
+  id: applyId,
+  userId,
+  jdId,
+  status: 'applied',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockJd = { id: jdId, title: '백엔드 개발자' };
+
+describe('createApplication', () => {
+  it('정상 지원 — apply 생성', async () => {
+    (
+      prisma.jobDescription.findUnique as unknown as jest.Mock
+    ).mockResolvedValue(mockJd);
+    (prisma.apply.findFirst as unknown as jest.Mock).mockResolvedValue(null);
+    (prisma.apply.create as unknown as jest.Mock).mockResolvedValue(mockApply);
+
+    const result = await createApplication(userId, jdId);
+
+    expect(result).toEqual(mockApply);
+    expect(prisma.apply.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { userId, jdId, status: 'applied' } })
+    );
+  });
+
+  it('JD 없음 → DomainError NOT_FOUND', async () => {
+    (
+      prisma.jobDescription.findUnique as unknown as jest.Mock
+    ).mockResolvedValue(null);
+
+    await expect(createApplication(userId, jdId)).rejects.toThrow(DomainError);
+    await expect(createApplication(userId, jdId)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('중복 지원 → DomainError CONFLICT', async () => {
+    (
+      prisma.jobDescription.findUnique as unknown as jest.Mock
+    ).mockResolvedValue(mockJd);
+    (prisma.apply.findFirst as unknown as jest.Mock).mockResolvedValue(
+      mockApply
+    );
+
+    await expect(createApplication(userId, jdId)).rejects.toThrow(DomainError);
+    await expect(createApplication(userId, jdId)).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+  });
+});
+
+describe('withdrawApplication', () => {
+  it('정상 철회 — status: withdrawn으로 업데이트', async () => {
+    (prisma.apply.findUnique as unknown as jest.Mock).mockResolvedValue(
+      mockApply
+    );
+    (prisma.apply.update as unknown as jest.Mock).mockResolvedValue({
+      ...mockApply,
+      status: 'withdrawn',
+    });
+
+    const result = await withdrawApplication(userId, applyId);
+
+    expect(result).toMatchObject({ status: 'withdrawn' });
+    expect(prisma.apply.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'withdrawn' } })
+    );
+  });
+
+  it('소유권 불일치 → DomainError FORBIDDEN', async () => {
+    (prisma.apply.findUnique as unknown as jest.Mock).mockResolvedValue({
+      ...mockApply,
+      userId: 'other-user',
+    });
+
+    await expect(withdrawApplication(userId, applyId)).rejects.toThrow(
+      DomainError
+    );
+    await expect(withdrawApplication(userId, applyId)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+  });
+
+  it('status=accepted → 철회 불가, DomainError CONFLICT', async () => {
+    (prisma.apply.findUnique as unknown as jest.Mock).mockResolvedValue({
+      ...mockApply,
+      status: 'accepted',
+    });
+
+    await expect(withdrawApplication(userId, applyId)).rejects.toThrow(
+      DomainError
+    );
+    await expect(withdrawApplication(userId, applyId)).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+  });
+});
+
+describe('getUserApplications', () => {
+  it('userId로 지원 목록 반환 (createdAt desc)', async () => {
+    (prisma.apply.findMany as unknown as jest.Mock).mockResolvedValue([
+      mockApply,
+    ]);
+
+    const result = await getUserApplications(userId);
+
+    expect(result).toEqual([mockApply]);
+    expect(prisma.apply.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId },
+        orderBy: { createdAt: 'desc' },
+      })
+    );
+  });
+});
+
+describe('getApplicationsForJd', () => {
+  it('jdId로 지원 목록 반환 (후보자 프로필 포함)', async () => {
+    const applyWithProfile = {
+      ...mockApply,
+      user: {
+        id: userId,
+        profilePublic: { firstName: '김' },
+        profileSkills: [],
+      },
+    };
+    (prisma.apply.findMany as unknown as jest.Mock).mockResolvedValue([
+      applyWithProfile,
+    ]);
+
+    const result = await getApplicationsForJd(jdId);
+
+    expect(result).toEqual([applyWithProfile]);
+    expect(prisma.apply.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { jdId } })
+    );
+  });
+});
+
+describe('getApplicantStats', () => {
+  it('jdId에 대한 상태별 카운트 반환', async () => {
+    const stats = [
+      { status: 'applied', _count: { _all: 5 } },
+      { status: 'accepted', _count: { _all: 2 } },
+    ];
+    (prisma.apply.groupBy as unknown as jest.Mock).mockResolvedValue(stats);
+
+    const result = await getApplicantStats(jdId);
+
+    expect(result).toEqual(stats);
+    expect(prisma.apply.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({ by: ['status'], where: { jdId } })
+    );
+  });
+});

--- a/lib/actions/applications.ts
+++ b/lib/actions/applications.ts
@@ -1,0 +1,71 @@
+'use server';
+
+import { ZodError } from 'zod';
+import { DomainError } from '@/lib/domain/errors';
+import { requireRole } from '@/lib/infrastructure/auth-utils';
+import { applySchema } from '@/lib/validations/application';
+import { revalidatePath } from 'next/cache';
+import {
+  createApplication,
+  withdrawApplication,
+  getUserApplications,
+  getApplicationsForJd as ucGetApplicationsForJd,
+} from '@/lib/use-cases/applications';
+
+type MutationResult = { success: true } | { error: string };
+type QueryResult<T> = { success: true; data: T } | { error: string };
+
+const APPLICATIONS_PATH = '/dashboard/candidate/applications';
+
+function handleError(e: unknown): { error: string } {
+  if (e instanceof DomainError) return { error: e.message };
+  if (e instanceof ZodError) return { error: '입력값이 유효하지 않습니다' };
+  throw e;
+}
+
+export async function createApply(input: unknown): Promise<MutationResult> {
+  try {
+    const user = await requireRole('candidate');
+    const { jdId } = applySchema.parse(input);
+    await createApplication(user.userId, jdId);
+    revalidatePath(APPLICATIONS_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function withdrawApply(applyId: string): Promise<MutationResult> {
+  try {
+    const user = await requireRole('candidate');
+    await withdrawApplication(user.userId, applyId);
+    revalidatePath(APPLICATIONS_PATH);
+    return { success: true };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function getMyApplications(): Promise<
+  QueryResult<Awaited<ReturnType<typeof getUserApplications>>>
+> {
+  try {
+    const user = await requireRole('candidate');
+    const data = await getUserApplications(user.userId);
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function getApplicationsForJd(
+  jdId: string
+): Promise<QueryResult<Awaited<ReturnType<typeof ucGetApplicationsForJd>>>> {
+  try {
+    await requireRole('recruiter', 'admin');
+    const data = await ucGetApplicationsForJd(jdId);
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}

--- a/lib/use-cases/applications.ts
+++ b/lib/use-cases/applications.ts
@@ -1,0 +1,71 @@
+import { prisma } from '@/lib/infrastructure/db';
+import { notFound, conflict } from '@/lib/domain/errors';
+import { assertOwnership } from '@/lib/domain/authorization';
+
+// 지원자 프로필 포함 (부분 조회 — 채용담당자 뷰)
+// AppUser에서 profilePublic(기본 정보)과 profileSkills(스킬 목록)를 직접 조회
+const APPLY_CANDIDATE_INCLUDE = {
+  user: {
+    include: {
+      profilePublic: true,
+      profileSkills: { include: { skill: true } },
+    },
+  },
+} as const;
+
+export async function createApplication(userId: string, jdId: string) {
+  const jd = await prisma.jobDescription.findUnique({ where: { id: jdId } });
+  if (!jd) throw notFound('채용공고');
+
+  const existing = await prisma.apply.findFirst({ where: { userId, jdId } });
+  if (existing) throw conflict('이미 지원한 채용공고입니다');
+
+  return prisma.apply.create({ data: { userId, jdId, status: 'applied' } });
+}
+
+export async function withdrawApplication(userId: string, applyId: string) {
+  const apply = await prisma.apply.findUnique({ where: { id: applyId } });
+  if (!apply) throw notFound('지원');
+
+  assertOwnership(userId, apply.userId);
+
+  if (apply.status !== 'applied') {
+    throw conflict('지원 취소는 지원 상태에서만 가능합니다');
+  }
+
+  return prisma.apply.update({
+    where: { id: applyId },
+    data: { status: 'withdrawn' },
+  });
+}
+
+export async function getUserApplications(userId: string) {
+  return prisma.apply.findMany({
+    where: { userId },
+    include: {
+      jd: {
+        include: {
+          job: { include: { family: true } },
+          org: true,
+        },
+      },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function getApplicationsForJd(jdId: string) {
+  return prisma.apply.findMany({
+    where: { jdId },
+    include: APPLY_CANDIDATE_INCLUDE,
+    orderBy: { createdAt: 'desc' },
+  });
+}
+
+export async function getApplicantStats(jdId: string) {
+  return prisma.apply.groupBy({
+    by: ['status'],
+    where: { jdId },
+    _count: { _all: true },
+  });
+}


### PR DESCRIPTION
## 요약

- 후보자 지원/철회/목록 조회 기능 구현
- 채용담당자용 지원자 조회 기능 구현
- 전체 테스트: 146개 통과 (기존 130개 → +16개)

## 변경 파일

### 신규 생성
- `lib/use-cases/applications.ts`: 5개 비즈니스 로직 함수
- `lib/actions/applications.ts`: 4개 서버 액션
- `__tests__/lib/use-cases/applications.test.ts`: 9개 테스트
- `__tests__/lib/actions/applications.test.ts`: 7개 테스트

### 수정
- `docs/implementation-plan.md`: Prompt 10 완료 표시 및 결과 섹션 추가

## 주요 구현

### Use-case 함수
- `createApplication`: JD 존재 확인 → 중복 지원 방지 → 생성
- `withdrawApplication`: 소유권 확인 + 상태 검증(`applied`만 철회 가능) → 철회
- `getUserApplications`: JD 정보 포함 목록
- `getApplicationsForJd`: 후보자 공개 프로필 + 스킬 포함 지원자 목록
- `getApplicantStats`: 상태별 카운트

### 주요 설계 결정
- 스킬 관계: `AppUser.profileSkills` 직접 조회 (ProfilesPublic에 직접 관계 없음)
- 중복 체크: P2002 에러 처리 대신 pre-check 방식으로 테스트 용이성 확보

## 테스트 계획

- [x] 단위 테스트 (use-case, action)
- [x] `pnpm jest` 전체 통과 확인
- [x] `tsc --noEmit` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)