### PR TITLE
feat(prompt12): Auth 모달 구현 (로그인 + 회원가입)

### DIFF
--- a/__tests__/features/auth/login-modal.test.tsx
+++ b/__tests__/features/auth/login-modal.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { LoginModal } from '@/features/auth/ui/login-modal';
+import { useAuthModal } from '@/features/auth/model/use-auth-modal';
+import { signIn } from '@/lib/infrastructure/auth-client';
+
+jest.mock('@/features/auth/model/use-auth-modal', () => ({
+  useAuthModal: jest.fn(),
+}));
+
+jest.mock('@/lib/infrastructure/auth-client', () => ({
+  signIn: { email: jest.fn() },
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockCloseAll = jest.fn();
+const mockOpenSignup = jest.fn();
+
+function mockModalState(isLoginOpen: boolean) {
+  (useAuthModal as unknown as jest.Mock).mockReturnValue({
+    isLoginOpen,
+    closeAll: mockCloseAll,
+    openSignup: mockOpenSignup,
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('LoginModal', () => {
+  it('isLoginOpen=true 일 때 다이얼로그 렌더링', () => {
+    mockModalState(true);
+    render(<LoginModal />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('isLoginOpen=false 일 때 다이얼로그 미렌더링', () => {
+    mockModalState(false);
+    render(<LoginModal />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('"Sign Up" 클릭 시 openSignup() 호출', () => {
+    mockModalState(true);
+    render(<LoginModal />);
+    fireEvent.click(screen.getByText(/sign up/i));
+    expect(mockOpenSignup).toHaveBeenCalledTimes(1);
+  });
+
+  it('이메일/비밀번호 입력 후 제출 시 signIn.email() 호출', async () => {
+    (signIn.email as jest.Mock).mockResolvedValue({});
+    mockModalState(true);
+    render(<LoginModal />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /log in/i }));
+
+    await waitFor(() => {
+      expect(signIn.email).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'test@example.com',
+          password: 'password123',
+        })
+      );
+    });
+  });
+});

--- a/__tests__/features/auth/signup-modal.test.tsx
+++ b/__tests__/features/auth/signup-modal.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { SignupModal } from '@/features/auth/ui/signup-modal';
+import { useAuthModal } from '@/features/auth/model/use-auth-modal';
+import { signUp } from '@/lib/infrastructure/auth-client';
+
+jest.mock('@/features/auth/model/use-auth-modal', () => ({
+  useAuthModal: jest.fn(),
+}));
+
+jest.mock('@/lib/infrastructure/auth-client', () => ({
+  signUp: { email: jest.fn() },
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockCloseAll = jest.fn();
+const mockOpenLogin = jest.fn();
+
+function mockModalState(isSignupOpen: boolean) {
+  (useAuthModal as unknown as jest.Mock).mockReturnValue({
+    isSignupOpen,
+    closeAll: mockCloseAll,
+    openLogin: mockOpenLogin,
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('SignupModal', () => {
+  it('isSignupOpen=true 일 때 다이얼로그 렌더링', () => {
+    mockModalState(true);
+    render(<SignupModal />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('isSignupOpen=false 일 때 다이얼로그 미렌더링', () => {
+    mockModalState(false);
+    render(<SignupModal />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('"Log in" 클릭 시 openLogin() 호출', () => {
+    mockModalState(true);
+    render(<SignupModal />);
+    fireEvent.click(screen.getByText(/log in/i));
+    expect(mockOpenLogin).toHaveBeenCalledTimes(1);
+  });
+
+  it('전체 필드 입력 후 제출 시 signUp.email() 호출', async () => {
+    (signUp.email as jest.Mock).mockResolvedValue({});
+    mockModalState(true);
+    render(<SignupModal />);
+
+    fireEvent.change(screen.getByLabelText(/name/i), {
+      target: { value: 'Test User' },
+    });
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/^password$/i), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByLabelText(/confirm password/i), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      expect(signUp.email).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Test User',
+          email: 'test@example.com',
+          password: 'password123',
+        })
+      );
+    });
+  });
+});

--- a/__tests__/features/auth/use-auth-modal.test.ts
+++ b/__tests__/features/auth/use-auth-modal.test.ts
@@ -1,0 +1,38 @@
+import { act, renderHook } from '@testing-library/react';
+import { useAuthModal } from '@/features/auth/model/use-auth-modal';
+
+// Zustand 스토어 초기화 — 각 테스트 후 상태 리셋
+beforeEach(() => {
+  useAuthModal.setState({ isLoginOpen: false, isSignupOpen: false });
+});
+
+describe('useAuthModal', () => {
+  it('초기 상태: 모달 모두 닫힘', () => {
+    const { result } = renderHook(() => useAuthModal());
+    expect(result.current.isLoginOpen).toBe(false);
+    expect(result.current.isSignupOpen).toBe(false);
+  });
+
+  it('openLogin(): 로그인 모달 열림, 회원가입 모달 닫힘', () => {
+    const { result } = renderHook(() => useAuthModal());
+    act(() => result.current.openLogin());
+    expect(result.current.isLoginOpen).toBe(true);
+    expect(result.current.isSignupOpen).toBe(false);
+  });
+
+  it('openSignup(): 회원가입 모달 열림, 로그인 모달 닫힘', () => {
+    const { result } = renderHook(() => useAuthModal());
+    act(() => result.current.openLogin());
+    act(() => result.current.openSignup());
+    expect(result.current.isSignupOpen).toBe(true);
+    expect(result.current.isLoginOpen).toBe(false);
+  });
+
+  it('closeAll(): 모든 모달 닫힘', () => {
+    const { result } = renderHook(() => useAuthModal());
+    act(() => result.current.openLogin());
+    act(() => result.current.closeAll());
+    expect(result.current.isLoginOpen).toBe(false);
+    expect(result.current.isSignupOpen).toBe(false);
+  });
+});

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -31,9 +31,9 @@ describe('공개 라우트', () => {
     expect(mockGetSession).not.toHaveBeenCalled();
   });
 
-  it('/announcement/* 은 세션 확인 후 처리', async () => {
+  it('/announcement/* 은 세션 확인 없이 통과', async () => {
     await proxy(makeRequest('/announcement/1'));
-    expect(mockGetSession).toHaveBeenCalledTimes(1);
+    expect(mockGetSession).not.toHaveBeenCalled();
   });
 
   it('/api/auth/* 은 세션 확인 없이 통과', async () => {
@@ -43,11 +43,13 @@ describe('공개 라우트', () => {
 });
 
 describe('보호 라우트', () => {
-  it('미인증 시 /login으로 리다이렉트', async () => {
+  it('미인증 시 /jobs?auth=required 로 리다이렉트', async () => {
     mockGetSession.mockResolvedValue(null);
     const res = await proxy(makeRequest('/dashboard/candidate/profile'));
     expect(res?.status).toBe(307);
-    expect(res?.headers.get('location')).toContain('/login');
+    const location = res?.headers.get('location') ?? '';
+    expect(location).toContain('/jobs');
+    expect(location).toContain('auth=required');
   });
 
   it('인증 시 통과', async () => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,13 @@
 import type { Metadata } from 'next';
 import { Inter, Geist_Mono } from 'next/font/google';
+import { Suspense } from 'react';
 import { GoogleAnalytics } from '@next/third-parties/google';
 import './globals.css';
 import Providers from '@/components/providers';
 import MainNav from '@/widgets/nav/ui/main-nav';
+import { LoginModal } from '@/features/auth/ui/login-modal';
+import { SignupModal } from '@/features/auth/ui/signup-modal';
+import { AuthRedirectHandler } from '@/features/auth/ui/auth-redirect-handler';
 
 const inter = Inter({
   variable: '--font-inter',
@@ -31,6 +35,11 @@ export default function RootLayout({
         <Providers>
           <MainNav />
           {children}
+          <LoginModal />
+          <SignupModal />
+          <Suspense>
+            <AuthRedirectHandler />
+          </Suspense>
         </Providers>
       </body>
       <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID!} />

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import * as React from 'react';
+import { XIcon } from 'lucide-react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        'h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30',
+        'focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50',
+        'aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import * as React from 'react';
+import { Label as LabelPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -119,7 +119,7 @@ middleware.ts
 | 9   | Catalog + JD Queries        | Data              | 카탈로그/채용공고 조회         | ✅   |
 | 10  | Application Management      | Data              | 지원, 철회, 채용담당자 조회    | ✅   |
 | 11  | Layout + Providers + Nav    | UI/Widget         | 프로바이더, 네비게이션 쉘      | ✅   |
-| 12  | Auth Modals                 | UI/Feature        | 로그인, 회원가입 모달          | ⬜   |
+| 12  | Auth Modals                 | UI/Feature        | 로그인, 회원가입 모달          | ✅   |
 | 13  | Profile Display             | UI/Entity         | 재사용 프로필 섹션 컴포넌트    | ⬜   |
 | 14  | Profile Edit                | UI/Feature        | 편집 폼 + 뮤테이션             | ⬜   |
 | 15  | Job Browse + Apply          | UI/Feature+Entity | 채용공고 탐색, 지원            | ⬜   |
@@ -803,8 +803,20 @@ Task 8: 테스트.
 - signup-modal: 이메일 형식, 비밀번호 일치 검증, signUp 호출.
 - middleware: /dashboard/* 미인증 → /jobs?auth=required.
 
-검증: pnpm test 통과.
+검증: pnpm test 통과 (161개), tsc --noEmit 통과.
 ```
+
+#### Prompt 12 결과
+
+- shadcn 컴포넌트 설치: `dialog`, `input`, `label`
+- `features/auth/model/use-auth-modal.ts`: Zustand 스토어 (isLoginOpen/isSignupOpen/openLogin/openSignup/closeAll)
+- `features/auth/ui/login-modal.tsx`: shadcn Dialog + TanStack Form (email, password), signIn.email(), 성공 시 /dashboard/candidate/profile 이동
+- `features/auth/ui/signup-modal.tsx`: shadcn Dialog + TanStack Form (name, email, password, confirmPassword), signUp.email()
+- `features/auth/ui/auth-redirect-handler.tsx`: useSearchParams로 ?auth=required 감지 → 로그인 모달 자동 오픈 (Suspense 래핑)
+- `app/layout.tsx`: LoginModal, SignupModal, AuthRedirectHandler 전역 렌더링
+- `widgets/nav/ui/main-nav.tsx`: Log in/Sign Up 버튼에 openLogin/openSignup 연결
+- `proxy.ts`: /login,/signup 공개 경로 제거, /announcement 공개 추가, isAuthPage 로직 제거, 미인증 → /jobs?auth=required
+- 테스트: 161개 통과, tsc --noEmit 클린
 
 ---
 

--- a/features/auth/model/use-auth-modal.ts
+++ b/features/auth/model/use-auth-modal.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+interface AuthModalStore {
+  isLoginOpen: boolean;
+  isSignupOpen: boolean;
+  openLogin: () => void;
+  openSignup: () => void;
+  closeAll: () => void;
+}
+
+export const useAuthModal = create<AuthModalStore>((set) => ({
+  isLoginOpen: false,
+  isSignupOpen: false,
+  openLogin: () => set({ isLoginOpen: true, isSignupOpen: false }),
+  openSignup: () => set({ isSignupOpen: true, isLoginOpen: false }),
+  closeAll: () => set({ isLoginOpen: false, isSignupOpen: false }),
+}));

--- a/features/auth/ui/auth-redirect-handler.tsx
+++ b/features/auth/ui/auth-redirect-handler.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useAuthModal } from '../model/use-auth-modal';
+
+export function AuthRedirectHandler() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { openLogin } = useAuthModal();
+
+  useEffect(() => {
+    if (searchParams.get('auth') === 'required') {
+      openLogin();
+      router.replace('/jobs');
+    }
+  }, [searchParams, openLogin, router]);
+
+  return null;
+}

--- a/features/auth/ui/login-modal.tsx
+++ b/features/auth/ui/login-modal.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from '@tanstack/react-form';
+import { z } from 'zod';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { signIn } from '@/lib/infrastructure/auth-client';
+import { useAuthModal } from '../model/use-auth-modal';
+
+const loginSchema = z.object({
+  email: z.string().email('유효한 이메일을 입력하세요'),
+  password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다'),
+});
+
+export function LoginModal() {
+  const { isLoginOpen, closeAll, openSignup } = useAuthModal();
+  const router = useRouter();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const form = useForm({
+    defaultValues: { email: '', password: '' },
+    validators: { onSubmit: loginSchema },
+    onSubmit: async ({ value }) => {
+      setServerError(null);
+      await signIn.email({
+        email: value.email,
+        password: value.password,
+        fetchOptions: {
+          onSuccess: () => {
+            closeAll();
+            router.push('/dashboard/candidate/profile');
+          },
+          onError: (ctx) => {
+            setServerError(
+              (ctx.error as { message?: string })?.message ??
+                '로그인에 실패했습니다'
+            );
+          },
+        },
+      });
+    },
+  });
+
+  return (
+    <Dialog open={isLoginOpen} onOpenChange={(open) => !open && closeAll()}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>로그인</DialogTitle>
+        </DialogHeader>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit();
+          }}
+          className="flex flex-col gap-4"
+        >
+          <form.Field name="email">
+            {(field) => (
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="login-email">Email</Label>
+                <Input
+                  id="login-email"
+                  type="email"
+                  autoComplete="email"
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  onBlur={field.handleBlur}
+                />
+                {field.state.meta.isTouched &&
+                  field.state.meta.errors.length > 0 && (
+                    <p className="text-xs text-destructive">
+                      {String(
+                        field.state.meta.errors[0] instanceof Object
+                          ? (field.state.meta.errors[0] as { message: string })
+                              .message
+                          : field.state.meta.errors[0]
+                      )}
+                    </p>
+                  )}
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="password">
+            {(field) => (
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="login-password">Password</Label>
+                <Input
+                  id="login-password"
+                  type="password"
+                  autoComplete="current-password"
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  onBlur={field.handleBlur}
+                />
+                {field.state.meta.isTouched &&
+                  field.state.meta.errors.length > 0 && (
+                    <p className="text-xs text-destructive">
+                      {String(
+                        field.state.meta.errors[0] instanceof Object
+                          ? (field.state.meta.errors[0] as { message: string })
+                              .message
+                          : field.state.meta.errors[0]
+                      )}
+                    </p>
+                  )}
+              </div>
+            )}
+          </form.Field>
+
+          {serverError && (
+            <p className="text-sm text-destructive">{serverError}</p>
+          )}
+
+          <form.Subscribe selector={(s) => s.isSubmitting}>
+            {(isSubmitting) => (
+              <Button type="submit" disabled={isSubmitting} className="w-full">
+                {isSubmitting ? '로그인 중...' : 'Log in'}
+              </Button>
+            )}
+          </form.Subscribe>
+
+          <p className="text-center text-sm text-muted-foreground">
+            계정이 없으신가요?{' '}
+            <button
+              type="button"
+              onClick={openSignup}
+              className="font-medium text-brand hover:underline"
+            >
+              Sign Up
+            </button>
+          </p>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/features/auth/ui/signup-modal.tsx
+++ b/features/auth/ui/signup-modal.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from '@tanstack/react-form';
+import { z } from 'zod';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { signUp } from '@/lib/infrastructure/auth-client';
+import { useAuthModal } from '../model/use-auth-modal';
+
+const signupSchema = z
+  .object({
+    name: z.string().min(2, '이름은 2자 이상이어야 합니다'),
+    email: z.string().email('유효한 이메일을 입력하세요'),
+    password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: '비밀번호가 일치하지 않습니다',
+    path: ['confirmPassword'],
+  });
+
+export function SignupModal() {
+  const { isSignupOpen, closeAll, openLogin } = useAuthModal();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const form = useForm({
+    defaultValues: { name: '', email: '', password: '', confirmPassword: '' },
+    validators: { onSubmit: signupSchema },
+    onSubmit: async ({ value }) => {
+      setServerError(null);
+      await signUp.email({
+        name: value.name,
+        email: value.email,
+        password: value.password,
+        fetchOptions: {
+          onSuccess: () => {
+            closeAll();
+          },
+          onError: (ctx) => {
+            setServerError(
+              (ctx.error as { message?: string })?.message ??
+                '회원가입에 실패했습니다'
+            );
+          },
+        },
+      });
+    },
+  });
+
+  return (
+    <Dialog open={isSignupOpen} onOpenChange={(open) => !open && closeAll()}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>회원가입</DialogTitle>
+        </DialogHeader>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit();
+          }}
+          className="flex flex-col gap-4"
+        >
+          <form.Field name="name">
+            {(field) => (
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="signup-name">Name</Label>
+                <Input
+                  id="signup-name"
+                  autoComplete="name"
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  onBlur={field.handleBlur}
+                />
+                {field.state.meta.isTouched &&
+                  field.state.meta.errors.length > 0 && (
+                    <p className="text-xs text-destructive">
+                      {String(
+                        field.state.meta.errors[0] instanceof Object
+                          ? (field.state.meta.errors[0] as { message: string })
+                              .message
+                          : field.state.meta.errors[0]
+                      )}
+                    </p>
+                  )}
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="email">
+            {(field) => (
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="signup-email">Email</Label>
+                <Input
+                  id="signup-email"
+                  type="email"
+                  autoComplete="email"
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  onBlur={field.handleBlur}
+                />
+                {field.state.meta.isTouched &&
+                  field.state.meta.errors.length > 0 && (
+                    <p className="text-xs text-destructive">
+                      {String(
+                        field.state.meta.errors[0] instanceof Object
+                          ? (field.state.meta.errors[0] as { message: string })
+                              .message
+                          : field.state.meta.errors[0]
+                      )}
+                    </p>
+                  )}
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="password">
+            {(field) => (
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="signup-password">Password</Label>
+                <Input
+                  id="signup-password"
+                  type="password"
+                  autoComplete="new-password"
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  onBlur={field.handleBlur}
+                />
+                {field.state.meta.isTouched &&
+                  field.state.meta.errors.length > 0 && (
+                    <p className="text-xs text-destructive">
+                      {String(
+                        field.state.meta.errors[0] instanceof Object
+                          ? (field.state.meta.errors[0] as { message: string })
+                              .message
+                          : field.state.meta.errors[0]
+                      )}
+                    </p>
+                  )}
+              </div>
+            )}
+          </form.Field>
+
+          <form.Field name="confirmPassword">
+            {(field) => (
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="signup-confirm-password">
+                  Confirm Password
+                </Label>
+                <Input
+                  id="signup-confirm-password"
+                  type="password"
+                  autoComplete="new-password"
+                  value={field.state.value}
+                  onChange={(e) => field.handleChange(e.target.value)}
+                  onBlur={field.handleBlur}
+                />
+                {field.state.meta.isTouched &&
+                  field.state.meta.errors.length > 0 && (
+                    <p className="text-xs text-destructive">
+                      {String(
+                        field.state.meta.errors[0] instanceof Object
+                          ? (field.state.meta.errors[0] as { message: string })
+                              .message
+                          : field.state.meta.errors[0]
+                      )}
+                    </p>
+                  )}
+              </div>
+            )}
+          </form.Field>
+
+          {serverError && (
+            <p className="text-sm text-destructive">{serverError}</p>
+          )}
+
+          <form.Subscribe selector={(s) => s.isSubmitting}>
+            {(isSubmitting) => (
+              <Button type="submit" disabled={isSubmitting} className="w-full">
+                {isSubmitting ? '가입 중...' : 'Sign Up'}
+              </Button>
+            )}
+          </form.Subscribe>
+
+          <p className="text-center text-sm text-muted-foreground">
+            이미 계정이 있으신가요?{' '}
+            <button
+              type="button"
+              onClick={openLogin}
+              className="font-medium text-brand hover:underline"
+            >
+              Log in
+            </button>
+          </p>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,37 +4,23 @@ import { auth } from '@/lib/infrastructure/auth';
 function isPublicPath(pathname: string): boolean {
   return (
     pathname === '/' ||
-    pathname.startsWith('/login') ||
-    pathname.startsWith('/signup') ||
     pathname.startsWith('/jobs') ||
+    pathname.startsWith('/announcement') ||
     pathname.startsWith('/api/auth')
   );
 }
 
-function isAuthPage(pathname: string): boolean {
-  return pathname.startsWith('/login') || pathname.startsWith('/signup');
-}
-
 export async function proxy(request: NextRequest) {
-  const { pathname } = request.nextUrl;
-  const publicPath = isPublicPath(pathname);
-  const authPage = isAuthPage(pathname);
-
-  // 순수 공개 경로 (인증 페이지 제외) — 세션 확인 불필요
-  if (publicPath && !authPage) {
+  // 공개 경로 — 세션 확인 불필요
+  if (isPublicPath(request.nextUrl.pathname)) {
     return NextResponse.next();
   }
 
   const session = await auth.api.getSession({ headers: request.headers });
 
-  // 인증 페이지 + 로그인됨 → 대시보드로
-  if (authPage && session) {
-    return NextResponse.redirect(new URL('/dashboard', request.url));
-  }
-
-  // 보호 경로 + 미인증 → 로그인으로
-  if (!publicPath && !session) {
-    return NextResponse.redirect(new URL('/login', request.url));
+  // 보호 경로 + 미인증 → 로그인 모달 트리거 (Prompt 12)
+  if (!session) {
+    return NextResponse.redirect(new URL('/jobs?auth=required', request.url));
   }
 
   return NextResponse.next();

--- a/widgets/nav/ui/main-nav.tsx
+++ b/widgets/nav/ui/main-nav.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useSession } from '@/hooks/use-session';
 import { Button } from '@/components/ui/button';
+import { useAuthModal } from '@/features/auth/model/use-auth-modal';
 import UserMenu from './user-menu';
 
 const NAV_LINKS = [
@@ -15,6 +16,7 @@ export default function MainNav() {
   const pathname = usePathname();
   const { data: session } = useSession();
   const user = session?.user;
+  const { openLogin, openSignup } = useAuthModal();
 
   return (
     <nav className="flex h-14 items-center justify-between border-b bg-white px-6">
@@ -59,10 +61,10 @@ export default function MainNav() {
           />
         ) : (
           <>
-            <Button variant="ghost" size="sm">
+            <Button variant="ghost" size="sm" onClick={openLogin}>
               Log in
             </Button>
-            <Button variant="ghost" size="sm">
+            <Button variant="ghost" size="sm" onClick={openSignup}>
               Sign Up
             </Button>
           </>


### PR DESCRIPTION
## 개요

Prompt 12 구현: Auth 모달 다이얼로그 (Figma 기반, 별도 auth 페이지 없음)

## 변경 사항

- **shadcn 컴포넌트 설치**: dialog, input, label
- **`features/auth/model/use-auth-modal.ts`**: Zustand 스토어 (isLoginOpen, isSignupOpen, openLogin, openSignup, closeAll)
- **`features/auth/ui/login-modal.tsx`**: shadcn Dialog + TanStack Form v1 (email, password, Zod 검증), signIn.email(), 성공 시 /dashboard/candidate/profile 이동
- **`features/auth/ui/signup-modal.tsx`**: shadcn Dialog + TanStack Form v1 (name, email, password, confirmPassword), signUp.email()
- **`features/auth/ui/auth-redirect-handler.tsx`**: useSearchParams로 ?auth=required 감지 → 로그인 모달 자동 오픈 (Suspense 래핑)
- **`app/layout.tsx`**: LoginModal, SignupModal, AuthRedirectHandler 전역 렌더링
- **`widgets/nav/ui/main-nav.tsx`**: Log in/Sign Up 버튼에 openLogin/openSignup 연결
- **`proxy.ts`**: /login,/signup 공개 경로 제거, /announcement 공개 추가, isAuthPage 로직 제거, 미인증 → /jobs?auth=required 리다이렉트

## 추가 수정 사항

rename 커밋(`3bb3785`)에서 실수로 Prompt 11 변경 사항이 되돌려진 `proxy.ts`를 올바른 상태로 복원

## 테스트

- 161개 테스트 통과 (기존 149개 + 신규 12개)
- `tsc --noEmit` 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)