### PR TITLE
feat(entities): Prompt 13 — 프로필 엔티티 표시 컴포넌트

### DIFF
--- a/__tests__/entities/profile/career-list.test.tsx
+++ b/__tests__/entities/profile/career-list.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import { CareerList } from '@/entities/profile/ui/career-list';
+
+const baseCareer = {
+  id: '1',
+  companyName: '삼성전자',
+  positionTitle: '시니어 개발자',
+  employmentType: 'full_time',
+  startDate: new Date('2021-03-01'),
+  endDate: null,
+  description: null,
+  sortOrder: 0,
+  job: { displayNameEn: 'Software Engineer' },
+};
+
+describe('CareerList', () => {
+  it('renders company and position', () => {
+    render(<CareerList careers={[baseCareer]} />);
+    expect(screen.getByText('삼성전자')).toBeInTheDocument();
+    expect(screen.getByText('시니어 개발자')).toBeInTheDocument();
+  });
+
+  it('renders job displayNameEn', () => {
+    render(<CareerList careers={[baseCareer]} />);
+    expect(screen.getByText('Software Engineer')).toBeInTheDocument();
+  });
+
+  it('renders employment type label as badge', () => {
+    render(<CareerList careers={[baseCareer]} />);
+    expect(screen.getByText('정규직')).toBeInTheDocument();
+  });
+
+  it('formats startDate as YYYY.MM', () => {
+    render(<CareerList careers={[baseCareer]} />);
+    expect(screen.getByText(/2021\.03/)).toBeInTheDocument();
+  });
+
+  it('renders 현재 when endDate is null', () => {
+    render(<CareerList careers={[baseCareer]} />);
+    expect(screen.getByText(/현재/)).toBeInTheDocument();
+  });
+
+  it('renders formatted endDate when provided', () => {
+    const career = { ...baseCareer, endDate: new Date('2023-06-01') };
+    render(<CareerList careers={[career]} />);
+    expect(screen.getByText(/2023\.06/)).toBeInTheDocument();
+  });
+
+  it('renders empty state when careers is empty', () => {
+    render(<CareerList careers={[]} />);
+    expect(screen.getByText('경력 없음')).toBeInTheDocument();
+  });
+});

--- a/__tests__/entities/profile/profile-header.test.tsx
+++ b/__tests__/entities/profile/profile-header.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { ProfileHeader } from '@/entities/profile/ui/profile-header';
+
+describe('ProfileHeader', () => {
+  it('renders full name', () => {
+    render(<ProfileHeader firstName="길동" lastName="홍" />);
+    expect(screen.getByRole('heading')).toHaveTextContent('길동 홍');
+  });
+
+  it('renders aboutMe when provided', () => {
+    render(
+      <ProfileHeader firstName="길동" lastName="홍" aboutMe="안녕하세요" />
+    );
+    expect(screen.getByText('안녕하세요')).toBeInTheDocument();
+  });
+
+  it('omits aboutMe paragraph when null', () => {
+    render(<ProfileHeader firstName="길동" lastName="홍" aboutMe={null} />);
+    expect(screen.queryByText('안녕하세요')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/entities/profile/skill-badges.test.tsx
+++ b/__tests__/entities/profile/skill-badges.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { SkillBadges } from '@/entities/profile/ui/skill-badges';
+
+describe('SkillBadges', () => {
+  it('renders each skill displayNameEn', () => {
+    const skills = [
+      { skill: { displayNameEn: 'TypeScript' } },
+      { skill: { displayNameEn: 'React' } },
+    ];
+    render(<SkillBadges skills={skills} />);
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+    expect(screen.getByText('React')).toBeInTheDocument();
+  });
+
+  it('renders empty state when skills is empty', () => {
+    render(<SkillBadges skills={[]} />);
+    expect(screen.getByText('등록된 스킬 없음')).toBeInTheDocument();
+  });
+});

--- a/app/(dashboard)/candidate/profile/page.tsx
+++ b/app/(dashboard)/candidate/profile/page.tsx
@@ -1,0 +1,103 @@
+import Link from 'next/link';
+import { requireUser } from '@/lib/infrastructure/auth-utils';
+import { getMyProfile } from '@/lib/actions/profile';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ProfileHeader } from '@/entities/profile/ui/profile-header';
+import { ContactInfo } from '@/entities/profile/ui/contact-info';
+import { SkillBadges } from '@/entities/profile/ui/skill-badges';
+import { CareerList } from '@/entities/profile/ui/career-list';
+import { EducationList } from '@/entities/profile/ui/education-list';
+import { LanguageList } from '@/entities/profile/ui/language-list';
+import { UrlList } from '@/entities/profile/ui/url-list';
+
+export default async function CandidateProfilePage() {
+  const user = await requireUser();
+  const result = await getMyProfile();
+
+  if ('error' in result) {
+    return <p className="text-destructive">{result.error}</p>;
+  }
+
+  const {
+    profilePublic,
+    profilePrivate,
+    careers,
+    educations,
+    languages,
+    urls,
+    profileSkills,
+  } = result.data;
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex items-start justify-between">
+        <ProfileHeader
+          firstName={profilePublic?.firstName ?? ''}
+          lastName={profilePublic?.lastName ?? ''}
+          aboutMe={profilePublic?.aboutMe}
+        />
+        <Button variant="outline" size="sm" asChild>
+          <Link href="/dashboard/candidate/profile/edit">편집</Link>
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">연락처</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ContactInfo
+            phoneNumber={profilePrivate?.phoneNumber}
+            email={user.email}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">스킬</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SkillBadges skills={profileSkills} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">경력</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CareerList careers={careers} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">학력</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <EducationList educations={educations} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">언어</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <LanguageList languages={languages} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">링크</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <UrlList urls={urls} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Slot } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground [a&]:hover:bg-primary/90',
+        secondary:
+          'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90',
+        destructive:
+          'bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        outline:
+          'border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        ghost: '[a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 [a&]:hover:underline',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+function Badge({
+  className,
+  variant = 'default',
+  asChild = false,
+  ...props
+}: React.ComponentProps<'span'> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : 'span';
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        'flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn('leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        'col-start-2 row-span-2 row-start-1 self-start justify-self-end',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn('px-6', className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn('flex items-center px-6 [.border-t]:pt-6', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -120,7 +120,7 @@ middleware.ts
 | 10  | Application Management      | Data              | 지원, 철회, 채용담당자 조회    | ✅   |
 | 11  | Layout + Providers + Nav    | UI/Widget         | 프로바이더, 네비게이션 쉘      | ✅   |
 | 12  | Auth Modals                 | UI/Feature        | 로그인, 회원가입 모달          | ✅   |
-| 13  | Profile Display             | UI/Entity         | 재사용 프로필 섹션 컴포넌트    | ⬜   |
+| 13  | Profile Display             | UI/Entity         | 재사용 프로필 섹션 컴포넌트    | ✅   |
 | 14  | Profile Edit                | UI/Feature        | 편집 폼 + 뮤테이션             | ⬜   |
 | 15  | Job Browse + Apply          | UI/Feature+Entity | 채용공고 탐색, 지원            | ⬜   |
 | 16  | Recruiter Dashboard         | UI/Feature        | 지원자 조회, 후보자 프로필     | ⬜   |
@@ -864,6 +864,26 @@ Task 4: career-list, skill-badges, profile-header 테스트.
 
 검증: pnpm test 통과.
 ```
+
+#### Prompt 13 결과
+
+- shadcn 컴포넌트 설치: `badge`, `card`
+- `entities/profile/ui/_utils.ts`: `formatDate` (UTC 기반), EMPLOYMENT_TYPE/PROFICIENCY/EDUCATION_TYPE 레이블 맵
+- `entities/profile/ui/profile-header.tsx`: 이름 + aboutMe
+- `entities/profile/ui/career-list.tsx`: 경력 목록 (Badge, 날짜 범위, 빈 상태)
+- `entities/profile/ui/education-list.tsx`: 학력 목록 (유형 Badge, 졸업여부 Badge)
+- `entities/profile/ui/language-list.tsx`: 언어 + 숙련도 Badge
+- `entities/profile/ui/skill-badges.tsx`: 스킬 뱃지 목록
+- `entities/profile/ui/url-list.tsx`: 외부 링크 목록
+- `entities/profile/ui/contact-info.tsx`: 연락처/이메일 (`미제공` 처리)
+- `app/(dashboard)/candidate/profile/page.tsx`: async Server Component, getMyProfile() + requireUser()로 데이터 조합, Card 섹션 구조
+- 단위 테스트: profile-header(3), career-list(7), skill-badges(2) — 12개 추가
+- 전체 테스트: 173개 통과, tsc --noEmit 클린
+
+계획 대비 변경 사항:
+
+- `QueryResult` 타입 좁히기: `!result.success`가 아닌 `'error' in result`로 분기 — 에러 브랜치에 `success` 프로퍼티 없음
+- 엔티티 컴포넌트 props에 Prisma 타입 미사용 — 로컬 타입 정의로 entity 레이어 독립성 유지
 
 ---
 

--- a/entities/profile/ui/_utils.ts
+++ b/entities/profile/ui/_utils.ts
@@ -1,0 +1,29 @@
+export function formatDate(date: Date): string {
+  return `${date.getUTCFullYear()}.${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+export const EMPLOYMENT_TYPE_LABELS: Record<string, string> = {
+  full_time: '정규직',
+  part_time: '파트타임',
+  intern: '인턴',
+  freelance: '프리랜서',
+};
+
+export const PROFICIENCY_LABELS: Record<string, string> = {
+  native: '원어민',
+  fluent: '유창',
+  professional: '업무 가능',
+  basic: '기초',
+};
+
+export const EDUCATION_TYPE_LABELS: Record<string, string> = {
+  vet_elementary: '직업 초급',
+  vet_intermediate: '직업 중급',
+  vet_college: '직업 대학',
+  higher_bachelor: '학사',
+  higher_master: '석사',
+  higher_doctorate: '박사',
+  continuing_education: '평생교육',
+  international_program: '국제 프로그램',
+  other: '기타',
+};

--- a/entities/profile/ui/career-list.tsx
+++ b/entities/profile/ui/career-list.tsx
@@ -1,0 +1,51 @@
+import { Badge } from '@/components/ui/badge';
+import { formatDate, EMPLOYMENT_TYPE_LABELS } from './_utils';
+
+type Career = {
+  id: string;
+  companyName: string;
+  positionTitle: string;
+  employmentType: string;
+  startDate: Date;
+  endDate: Date | null;
+  description: string | null;
+  sortOrder: number;
+  job: { displayNameEn: string };
+};
+
+type Props = {
+  careers: Career[];
+};
+
+export function CareerList({ careers }: Props) {
+  if (careers.length === 0) {
+    return <p className="text-muted-foreground">경력 없음</p>;
+  }
+
+  return (
+    <ul className="flex flex-col gap-4">
+      {careers.map((career) => (
+        <li key={career.id} className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold">{career.companyName}</span>
+            <Badge variant="secondary">
+              {EMPLOYMENT_TYPE_LABELS[career.employmentType] ??
+                career.employmentType}
+            </Badge>
+          </div>
+          <span className="text-sm">{career.positionTitle}</span>
+          <span className="text-sm text-muted-foreground">
+            {career.job.displayNameEn}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {formatDate(career.startDate)} ~{' '}
+            {career.endDate ? formatDate(career.endDate) : '현재'}
+          </span>
+          {career.description && (
+            <p className="mt-1 text-sm">{career.description}</p>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/entities/profile/ui/contact-info.tsx
+++ b/entities/profile/ui/contact-info.tsx
@@ -1,0 +1,19 @@
+type Props = {
+  phoneNumber?: string | null;
+  email?: string | null;
+};
+
+export function ContactInfo({ phoneNumber, email }: Props) {
+  return (
+    <dl className="flex flex-col gap-1 text-sm">
+      <div className="flex gap-2">
+        <dt className="text-muted-foreground">연락처</dt>
+        <dd>{phoneNumber ?? '미제공'}</dd>
+      </div>
+      <div className="flex gap-2">
+        <dt className="text-muted-foreground">이메일</dt>
+        <dd>{email ?? '미제공'}</dd>
+      </div>
+    </dl>
+  );
+}

--- a/entities/profile/ui/education-list.tsx
+++ b/entities/profile/ui/education-list.tsx
@@ -1,0 +1,48 @@
+import { Badge } from '@/components/ui/badge';
+import { formatDate, EDUCATION_TYPE_LABELS } from './_utils';
+
+type Education = {
+  id: string;
+  institutionName: string;
+  educationType: string;
+  field: string | null;
+  isGraduated: boolean;
+  startDate: Date;
+  endDate: Date | null;
+  sortOrder: number;
+};
+
+type Props = {
+  educations: Education[];
+};
+
+export function EducationList({ educations }: Props) {
+  if (educations.length === 0) {
+    return <p className="text-muted-foreground">학력 없음</p>;
+  }
+
+  return (
+    <ul className="flex flex-col gap-4">
+      {educations.map((edu) => (
+        <li key={edu.id} className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold">{edu.institutionName}</span>
+            <Badge variant="secondary">
+              {EDUCATION_TYPE_LABELS[edu.educationType] ?? edu.educationType}
+            </Badge>
+            <Badge variant={edu.isGraduated ? 'default' : 'outline'}>
+              {edu.isGraduated ? '졸업' : '재학 중'}
+            </Badge>
+          </div>
+          {edu.field && (
+            <span className="text-sm text-muted-foreground">{edu.field}</span>
+          )}
+          <span className="text-xs text-muted-foreground">
+            {formatDate(edu.startDate)} ~{' '}
+            {edu.endDate ? formatDate(edu.endDate) : '현재'}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/entities/profile/ui/language-list.tsx
+++ b/entities/profile/ui/language-list.tsx
@@ -1,0 +1,32 @@
+import { Badge } from '@/components/ui/badge';
+import { PROFICIENCY_LABELS } from './_utils';
+
+type Language = {
+  id: string;
+  language: string;
+  proficiency: string;
+  sortOrder: number;
+};
+
+type Props = {
+  languages: Language[];
+};
+
+export function LanguageList({ languages }: Props) {
+  if (languages.length === 0) {
+    return <p className="text-muted-foreground">등록된 언어 없음</p>;
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {languages.map((lang) => (
+        <li key={lang.id} className="flex items-center gap-2">
+          <span>{lang.language}</span>
+          <Badge variant="secondary">
+            {PROFICIENCY_LABELS[lang.proficiency] ?? lang.proficiency}
+          </Badge>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/entities/profile/ui/profile-header.tsx
+++ b/entities/profile/ui/profile-header.tsx
@@ -1,0 +1,16 @@
+type Props = {
+  firstName: string;
+  lastName: string;
+  aboutMe?: string | null;
+};
+
+export function ProfileHeader({ firstName, lastName, aboutMe }: Props) {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold">
+        {firstName} {lastName}
+      </h1>
+      {aboutMe && <p className="mt-2 text-muted-foreground">{aboutMe}</p>}
+    </div>
+  );
+}

--- a/entities/profile/ui/skill-badges.tsx
+++ b/entities/profile/ui/skill-badges.tsx
@@ -1,0 +1,25 @@
+import { Badge } from '@/components/ui/badge';
+
+type Skill = {
+  skill: { displayNameEn: string };
+};
+
+type Props = {
+  skills: Skill[];
+};
+
+export function SkillBadges({ skills }: Props) {
+  if (skills.length === 0) {
+    return <p className="text-muted-foreground">등록된 스킬 없음</p>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {skills.map((s, i) => (
+        <Badge key={i} variant="secondary">
+          {s.skill.displayNameEn}
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/entities/profile/ui/url-list.tsx
+++ b/entities/profile/ui/url-list.tsx
@@ -1,0 +1,33 @@
+type Url = {
+  id: string;
+  label: string;
+  url: string;
+  sortOrder: number;
+};
+
+type Props = {
+  urls: Url[];
+};
+
+export function UrlList({ urls }: Props) {
+  if (urls.length === 0) {
+    return <p className="text-muted-foreground">등록된 링크 없음</p>;
+  }
+
+  return (
+    <ul className="flex flex-col gap-1">
+      {urls.map((u) => (
+        <li key={u.id}>
+          <a
+            href={u.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-brand hover:underline"
+          >
+            {u.label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## 요약

- `entities/profile/ui/` FSD 엔티티 레이어 신규 생성
- shadcn `badge`, `card` 컴포넌트 추가
- 후보자 프로필 조회 페이지 구현 (`/dashboard/candidate/profile`)

## 변경 사항

### 엔티티 컴포넌트 (Server Components, `'use client'` 없음)
- `_utils.ts`: 날짜 포맷터 (`YYYY.MM`, UTC 기반), 고용유형/숙련도/학력유형 레이블 맵
- `ProfileHeader`: 이름 + aboutMe
- `CareerList`: 경력 목록 (뱃지, 날짜 범위, 빈 상태)
- `EducationList`: 학력 목록
- `LanguageList`: 언어 + 숙련도 뱃지
- `SkillBadges`: 스킬 뱃지 목록
- `UrlList`: 외부 링크 (새 탭)
- `ContactInfo`: 연락처/이메일 (`미제공` 처리)

### 프로필 페이지
- `app/(dashboard)/candidate/profile/page.tsx`: async Server Component
- `getMyProfile()` + `requireUser()` 조합으로 데이터 획득
- Card 섹션 구조로 각 프로필 영역 표시
- `'error' in result` 패턴으로 `QueryResult` 타입 분기

### 테스트
- `profile-header.test.tsx` (3개), `career-list.test.tsx` (7개), `skill-badges.test.tsx` (2개)
- 전체: 161개 → **173개** 통과

## 테스트 계획

- [ ] `pnpm test` → 173개 통과 확인
- [ ] `tsc --noEmit` → 에러 없음 확인
- [ ] 로그인 후 `/dashboard/candidate/profile` 접근 → 빈 상태로 정상 렌더링

🤖 Generated with [Claude Code](https://claude.com/claude-code)