### PR TITLE
feat: Prompt 14 — 프로필 편집 기능 (폼 컴포넌트 + 뮤테이션)

### DIFF
--- a/__tests__/features/profile-edit/career-form.test.tsx
+++ b/__tests__/features/profile-edit/career-form.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { CareerForm } from '@/features/profile-edit/ui/career-form';
+import {
+  useAddCareer,
+  useUpdateCareer,
+} from '@/features/profile-edit/model/use-profile-mutations';
+
+jest.mock('@/features/profile-edit/model/use-profile-mutations', () => ({
+  useAddCareer: jest.fn(),
+  useUpdateCareer: jest.fn(),
+  useDeleteCareer: jest.fn(),
+}));
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({ refresh: jest.fn() })),
+}));
+
+const jobFamilies = [
+  {
+    id: 'eng',
+    displayNameEn: 'Engineering',
+    jobs: [{ id: 'swe', displayNameEn: 'Software Engineer' }],
+  },
+];
+
+describe('CareerForm', () => {
+  const mockMutate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAddCareer as jest.Mock).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    });
+    (useUpdateCareer as jest.Mock).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    });
+  });
+
+  it('renders add mode with empty companyName and 저장 button', () => {
+    render(<CareerForm jobFamilies={jobFamilies} onSuccess={jest.fn()} />);
+    const input = screen.getByLabelText(/회사명/i);
+    expect(input).toHaveValue('');
+    expect(screen.getByRole('button', { name: /저장/i })).toBeInTheDocument();
+  });
+
+  it('renders edit mode with pre-filled companyName', () => {
+    render(
+      <CareerForm
+        jobFamilies={jobFamilies}
+        onSuccess={jest.fn()}
+        careerId="c1"
+        initialData={{
+          companyName: '삼성전자',
+          positionTitle: '개발자',
+          jobId: 'swe',
+          employmentType: 'full_time',
+          startDate: '2021-01-01',
+          endDate: undefined,
+          description: undefined,
+          sortOrder: 0,
+        }}
+      />
+    );
+    expect(screen.getByLabelText(/회사명/i)).toHaveValue('삼성전자');
+  });
+
+  it('button is disabled when isPending', () => {
+    (useAddCareer as jest.Mock).mockReturnValue({
+      mutate: mockMutate,
+      isPending: true,
+    });
+    render(<CareerForm jobFamilies={jobFamilies} onSuccess={jest.fn()} />);
+    expect(
+      screen.getByRole('button', { name: /저장|저장 중/i })
+    ).toBeDisabled();
+  });
+});

--- a/__tests__/features/profile-edit/skill-picker.test.tsx
+++ b/__tests__/features/profile-edit/skill-picker.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { SkillPicker } from '@/features/profile-edit/ui/skill-picker';
+import {
+  useAddSkill,
+  useDeleteSkill,
+} from '@/features/profile-edit/model/use-profile-mutations';
+
+jest.mock('@/lib/actions/catalog', () => ({ searchSkills: jest.fn() }));
+jest.mock('@/features/profile-edit/model/use-profile-mutations', () => ({
+  useAddSkill: jest.fn(),
+  useDeleteSkill: jest.fn(),
+}));
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({ refresh: jest.fn() })),
+}));
+
+const currentSkills = [
+  { skill: { id: 'typescript', displayNameEn: 'TypeScript' } },
+  { skill: { id: 'react', displayNameEn: 'React' } },
+];
+
+describe('SkillPicker', () => {
+  const mockDeleteMutate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAddSkill as jest.Mock).mockReturnValue({
+      mutate: jest.fn(),
+      isPending: false,
+    });
+    (useDeleteSkill as jest.Mock).mockReturnValue({
+      mutate: mockDeleteMutate,
+      isPending: false,
+    });
+  });
+
+  it('renders existing skill names', () => {
+    render(<SkillPicker currentSkills={currentSkills} />);
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+    expect(screen.getByText('React')).toBeInTheDocument();
+  });
+
+  it('renders a remove button for each skill', () => {
+    render(<SkillPicker currentSkills={currentSkills} />);
+    const removeButtons = screen.getAllByRole('button', {
+      name: /제거|삭제|×|✕/i,
+    });
+    expect(removeButtons).toHaveLength(currentSkills.length);
+  });
+
+  it('calls deleteSkill.mutate with skill id when remove is clicked', () => {
+    render(<SkillPicker currentSkills={currentSkills} />);
+    const removeButtons = screen.getAllByRole('button', {
+      name: /제거|삭제|×|✕/i,
+    });
+    fireEvent.click(removeButtons[0]);
+    expect(mockDeleteMutate).toHaveBeenCalledWith(
+      'typescript',
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+});

--- a/app/(dashboard)/candidate/profile/edit/page.tsx
+++ b/app/(dashboard)/candidate/profile/edit/page.tsx
@@ -1,0 +1,132 @@
+import Link from 'next/link';
+import { requireUser } from '@/lib/infrastructure/auth-utils';
+import { getMyProfile } from '@/lib/actions/profile';
+import { getJobFamilies } from '@/lib/actions/catalog';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ProfilePublicForm } from '@/features/profile-edit/ui/profile-public-form';
+import { ContactForm } from '@/features/profile-edit/ui/contact-form';
+import { CareerSection } from '@/features/profile-edit/ui/career-form';
+import { EducationSection } from '@/features/profile-edit/ui/education-form';
+import { LanguageSection } from '@/features/profile-edit/ui/language-form';
+import { UrlSection } from '@/features/profile-edit/ui/url-form';
+import { SkillPicker } from '@/features/profile-edit/ui/skill-picker';
+
+export default async function CandidateProfileEditPage() {
+  await requireUser();
+  const [profileResult, familiesResult] = await Promise.all([
+    getMyProfile(),
+    getJobFamilies(),
+  ]);
+
+  if ('error' in profileResult) {
+    return <p className="text-destructive">{profileResult.error}</p>;
+  }
+
+  const {
+    profilePublic,
+    profilePrivate,
+    careers: rawCareers,
+    educations: rawEducations,
+    languages,
+    urls,
+    profileSkills,
+  } = profileResult.data;
+  const jobFamilies = 'error' in familiesResult ? [] : familiesResult.data;
+
+  const careers = rawCareers.map((c) => ({
+    id: c.id,
+    companyName: c.companyName,
+    positionTitle: c.positionTitle,
+    jobId: c.jobId,
+    employmentType: c.employmentType,
+    startDate: c.startDate.toISOString().split('T')[0],
+    endDate: c.endDate?.toISOString().split('T')[0],
+    description: c.description ?? undefined,
+    sortOrder: c.sortOrder,
+  }));
+
+  const educations = rawEducations.map((e) => ({
+    id: e.id,
+    institutionName: e.institutionName,
+    educationType: e.educationType,
+    field: e.field ?? undefined,
+    isGraduated: e.isGraduated,
+    startDate: e.startDate.toISOString().split('T')[0],
+    endDate: e.endDate?.toISOString().split('T')[0],
+    sortOrder: e.sortOrder,
+  }));
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <Link
+        href="/dashboard/candidate/profile"
+        className="text-sm text-muted-foreground hover:underline"
+      >
+        ← 프로필로 돌아가기
+      </Link>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">기본 정보</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ProfilePublicForm initialData={profilePublic ?? undefined} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">연락처</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ContactForm initialData={profilePrivate ?? undefined} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">스킬</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SkillPicker currentSkills={profileSkills} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">경력</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CareerSection careers={careers} jobFamilies={jobFamilies} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">학력</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <EducationSection educations={educations} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">언어</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <LanguageSection languages={languages} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">링크</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <UrlSection urls={urls} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import * as React from 'react';
+import { Command as CommandPrimitive } from 'cmdk';
+import { SearchIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandDialog({
+  title = 'Command Palette',
+  description = 'Search for a command to run...',
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string;
+  description?: string;
+  className?: string;
+  showCloseButton?: boolean;
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn('overflow-hidden p-0', className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        'max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn('-mx-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        'ml-auto text-xs tracking-widest text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+};

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import * as React from 'react';
+import { Popover as PopoverPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn('flex flex-col gap-1 text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<'h2'>) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn('font-medium', className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<'p'>) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn('text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+};

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import * as React from 'react';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import { Select as SelectPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = 'default',
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = 'item-aligned',
+  align = 'center',
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          position === 'popper' &&
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1'
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn('px-2 py-1.5 text-xs text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        'flex cursor-default items-center justify-center py-1',
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        'flex cursor-default items-center justify-center py-1',
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -121,7 +121,7 @@ middleware.ts
 | 11  | Layout + Providers + Nav    | UI/Widget         | 프로바이더, 네비게이션 쉘      | ✅   |
 | 12  | Auth Modals                 | UI/Feature        | 로그인, 회원가입 모달          | ✅   |
 | 13  | Profile Display             | UI/Entity         | 재사용 프로필 섹션 컴포넌트    | ✅   |
-| 14  | Profile Edit                | UI/Feature        | 편집 폼 + 뮤테이션             | ⬜   |
+| 14  | Profile Edit                | UI/Feature        | 편집 폼 + 뮤테이션             | ✅   |
 | 15  | Job Browse + Apply          | UI/Feature+Entity | 채용공고 탐색, 지원            | ⬜   |
 | 16  | Recruiter Dashboard         | UI/Feature        | 지원자 조회, 후보자 프로필     | ⬜   |
 | 17  | Uploads + Polish + E2E      | Infra/Polish      | S3, 에러 처리, 스모크 테스트   | ⬜   |
@@ -931,6 +931,28 @@ Task 5: career-form, skill-picker 테스트.
 
 검증: pnpm test 통과.
 ```
+
+#### Prompt 14 결과
+
+- **생성 파일**: 11개 파일
+  - `features/profile-edit/model/use-profile-mutations.ts` — 16개 뮤테이션 훅
+  - `features/profile-edit/ui/profile-public-form.tsx` — 기본 정보 편집
+  - `features/profile-edit/ui/contact-form.tsx` — 연락처 편집
+  - `features/profile-edit/ui/career-form.tsx` — CareerForm + CareerSection
+  - `features/profile-edit/ui/education-form.tsx` — EducationForm + EducationSection
+  - `features/profile-edit/ui/language-form.tsx` — LanguageForm + LanguageSection
+  - `features/profile-edit/ui/url-form.tsx` — UrlForm + UrlSection
+  - `features/profile-edit/ui/skill-picker.tsx` — 디바운스 검색 + 스킬 추가/삭제
+  - `app/(dashboard)/candidate/profile/edit/page.tsx` — RSC 편집 페이지
+  - `__tests__/features/profile-edit/career-form.test.tsx`
+  - `__tests__/features/profile-edit/skill-picker.test.tsx`
+- **테스트**: 179개 통과 (기존 173 + 신규 6)
+- **타입 체크**: tsc --noEmit 오류 없음
+- **주요 패턴**:
+  - TanStack Form `defaultValues`를 명시적 타입으로 선언해 optional 프로퍼티(`?`) 보존 → Zod 스키마 validator 타입 호환
+  - 선택 필드 Input onChange: `e.target.value || undefined` (빈 문자열 → undefined 변환)
+  - Prisma Date → string 변환: `toISOString().split('T')[0]`
+  - `useEffect` 내 setState: setTimeout 콜백 안으로 이동해 동기 호출 회피 (react-hooks/set-state-in-effect)
 
 ---
 

--- a/features/profile-edit/model/use-profile-mutations.ts
+++ b/features/profile-edit/model/use-profile-mutations.ts
@@ -1,0 +1,97 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import {
+  updateProfilePublic,
+  updateProfilePrivate,
+  addProfileCareer,
+  updateProfileCareer,
+  deleteProfileCareer,
+  addProfileEducation,
+  updateProfileEducation,
+  deleteProfileEducation,
+  addProfileLanguage,
+  updateProfileLanguage,
+  deleteProfileLanguage,
+  addProfileUrl,
+  updateProfileUrl,
+  deleteProfileUrl,
+  addProfileSkill,
+  deleteProfileSkill,
+} from '@/lib/actions/profile';
+
+async function unwrap<T>(p: Promise<{ error: string } | T>): Promise<T> {
+  const r = await p;
+  if (typeof r === 'object' && r !== null && 'error' in r) {
+    throw new Error((r as { error: string }).error);
+  }
+  return r as T;
+}
+
+export const useUpdateProfilePublic = () =>
+  useMutation({ mutationFn: (d: unknown) => unwrap(updateProfilePublic(d)) });
+
+export const useUpdateProfilePrivate = () =>
+  useMutation({ mutationFn: (d: unknown) => unwrap(updateProfilePrivate(d)) });
+
+export const useAddCareer = () =>
+  useMutation({ mutationFn: (d: unknown) => unwrap(addProfileCareer(d)) });
+
+export const useUpdateCareer = () =>
+  useMutation({
+    mutationFn: ({ id, data }: { id: string; data: unknown }) =>
+      unwrap(updateProfileCareer(id, data)),
+  });
+
+export const useDeleteCareer = () =>
+  useMutation({ mutationFn: (id: string) => unwrap(deleteProfileCareer(id)) });
+
+export const useAddEducation = () =>
+  useMutation({ mutationFn: (d: unknown) => unwrap(addProfileEducation(d)) });
+
+export const useUpdateEducation = () =>
+  useMutation({
+    mutationFn: ({ id, data }: { id: string; data: unknown }) =>
+      unwrap(updateProfileEducation(id, data)),
+  });
+
+export const useDeleteEducation = () =>
+  useMutation({
+    mutationFn: (id: string) => unwrap(deleteProfileEducation(id)),
+  });
+
+export const useAddLanguage = () =>
+  useMutation({ mutationFn: (d: unknown) => unwrap(addProfileLanguage(d)) });
+
+export const useUpdateLanguage = () =>
+  useMutation({
+    mutationFn: ({ id, data }: { id: string; data: unknown }) =>
+      unwrap(updateProfileLanguage(id, data)),
+  });
+
+export const useDeleteLanguage = () =>
+  useMutation({
+    mutationFn: (id: string) => unwrap(deleteProfileLanguage(id)),
+  });
+
+export const useAddUrl = () =>
+  useMutation({ mutationFn: (d: unknown) => unwrap(addProfileUrl(d)) });
+
+export const useUpdateUrl = () =>
+  useMutation({
+    mutationFn: ({ id, data }: { id: string; data: unknown }) =>
+      unwrap(updateProfileUrl(id, data)),
+  });
+
+export const useDeleteUrl = () =>
+  useMutation({ mutationFn: (id: string) => unwrap(deleteProfileUrl(id)) });
+
+export const useAddSkill = () =>
+  useMutation({
+    mutationFn: (skillId: string) => unwrap(addProfileSkill(skillId)),
+  });
+
+export const useDeleteSkill = () =>
+  useMutation({
+    mutationFn: (skillId: string) => unwrap(deleteProfileSkill(skillId)),
+  });

--- a/features/profile-edit/ui/career-form.tsx
+++ b/features/profile-edit/ui/career-form.tsx
@@ -1,0 +1,367 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from '@tanstack/react-form';
+import { profileCareerSchema } from '@/lib/validations/profile';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { EMPLOYMENT_TYPE_LABELS } from '@/entities/profile/ui/_utils';
+import {
+  useAddCareer,
+  useUpdateCareer,
+  useDeleteCareer,
+} from '../model/use-profile-mutations';
+
+type JobFamily = {
+  id: string;
+  displayNameEn: string;
+  jobs: { id: string; displayNameEn: string }[];
+};
+
+type CareerData = {
+  companyName: string;
+  positionTitle: string;
+  jobId: string;
+  employmentType: string;
+  startDate: string;
+  endDate?: string;
+  description?: string;
+  sortOrder: number;
+};
+
+type CareerFormProps = {
+  jobFamilies: JobFamily[];
+  onSuccess: () => void;
+  careerId?: string;
+  initialData?: CareerData;
+};
+
+function FieldError({ errors }: { errors: unknown[] }) {
+  if (errors.length === 0) return null;
+  const msg =
+    typeof errors[0] === 'object' && errors[0] !== null
+      ? (errors[0] as { message: string }).message
+      : String(errors[0]);
+  return <p className="text-xs text-destructive">{msg}</p>;
+}
+
+export function CareerForm({
+  jobFamilies,
+  onSuccess,
+  careerId,
+  initialData,
+}: CareerFormProps) {
+  const addCareer = useAddCareer();
+  const updateCareer = useUpdateCareer();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const mutation = careerId ? updateCareer : addCareer;
+
+  const defaultValues: CareerData = {
+    companyName: initialData?.companyName ?? '',
+    positionTitle: initialData?.positionTitle ?? '',
+    jobId: initialData?.jobId ?? '',
+    employmentType: initialData?.employmentType ?? '',
+    startDate: initialData?.startDate ?? '',
+    endDate: initialData?.endDate,
+    description: initialData?.description,
+    sortOrder: initialData?.sortOrder ?? 0,
+  };
+
+  const form = useForm({
+    defaultValues,
+    validators: { onSubmit: profileCareerSchema },
+    onSubmit: async ({ value }) => {
+      setServerError(null);
+      const payload = value;
+      if (careerId) {
+        updateCareer.mutate(
+          { id: careerId, data: payload },
+          { onSuccess, onError: (err) => setServerError(err.message) }
+        );
+      } else {
+        addCareer.mutate(payload, {
+          onSuccess,
+          onError: (err) => setServerError(err.message),
+        });
+      }
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="flex flex-col gap-4"
+    >
+      <form.Field name="companyName">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="career-company">회사명</Label>
+            <Input
+              id="career-company"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+              onBlur={field.handleBlur}
+            />
+            {field.state.meta.isTouched && (
+              <FieldError errors={field.state.meta.errors} />
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="positionTitle">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="career-position">직위</Label>
+            <Input
+              id="career-position"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+              onBlur={field.handleBlur}
+            />
+            {field.state.meta.isTouched && (
+              <FieldError errors={field.state.meta.errors} />
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="jobId">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label>직무</Label>
+            <Select
+              value={field.state.value}
+              onValueChange={field.handleChange}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="직무 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {jobFamilies.map((family) => (
+                  <SelectGroup key={family.id}>
+                    <SelectLabel>{family.displayNameEn}</SelectLabel>
+                    {family.jobs.map((job) => (
+                      <SelectItem key={job.id} value={job.id}>
+                        {job.displayNameEn}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                ))}
+              </SelectContent>
+            </Select>
+            {field.state.meta.isTouched && (
+              <FieldError errors={field.state.meta.errors} />
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="employmentType">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label>고용 형태</Label>
+            <Select
+              value={field.state.value}
+              onValueChange={field.handleChange}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="고용 형태 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(EMPLOYMENT_TYPE_LABELS).map(
+                  ([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  )
+                )}
+              </SelectContent>
+            </Select>
+            {field.state.meta.isTouched && (
+              <FieldError errors={field.state.meta.errors} />
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      <div className="grid grid-cols-2 gap-4">
+        <form.Field name="startDate">
+          {(field) => (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="career-start">시작일</Label>
+              <Input
+                id="career-start"
+                type="date"
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+                onBlur={field.handleBlur}
+              />
+              {field.state.meta.isTouched && (
+                <FieldError errors={field.state.meta.errors} />
+              )}
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field name="endDate">
+          {(field) => (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="career-end">종료일 (선택)</Label>
+              <Input
+                id="career-end"
+                type="date"
+                value={field.state.value ?? ''}
+                onChange={(e) =>
+                  field.handleChange(e.target.value || undefined)
+                }
+                onBlur={field.handleBlur}
+              />
+              {field.state.meta.isTouched && (
+                <FieldError errors={field.state.meta.errors} />
+              )}
+            </div>
+          )}
+        </form.Field>
+      </div>
+
+      <form.Field name="description">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="career-desc">설명 (선택)</Label>
+            <Textarea
+              id="career-desc"
+              rows={3}
+              value={field.state.value ?? ''}
+              onChange={(e) => field.handleChange(e.target.value || undefined)}
+              onBlur={field.handleBlur}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+      <form.Subscribe selector={(s) => s.isSubmitting}>
+        {(isSubmitting) => (
+          <Button type="submit" disabled={isSubmitting || mutation.isPending}>
+            {isSubmitting || mutation.isPending ? '저장 중...' : '저장'}
+          </Button>
+        )}
+      </form.Subscribe>
+    </form>
+  );
+}
+
+type Career = CareerData & { id: string };
+
+type CareerSectionProps = {
+  careers: Career[];
+  jobFamilies: JobFamily[];
+};
+
+export function CareerSection({ careers, jobFamilies }: CareerSectionProps) {
+  const router = useRouter();
+  const deleteCareer = useDeleteCareer();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingCareer, setEditingCareer] = useState<Career | null>(null);
+
+  const openAdd = () => {
+    setEditingCareer(null);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (career: Career) => {
+    setEditingCareer(career);
+    setDialogOpen(true);
+  };
+
+  const handleSuccess = () => {
+    setDialogOpen(false);
+    router.refresh();
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {careers.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {careers.map((career) => (
+            <li
+              key={career.id}
+              className="flex items-center justify-between rounded border p-3"
+            >
+              <div>
+                <p className="font-medium">{career.companyName}</p>
+                <p className="text-sm text-muted-foreground">
+                  {career.positionTitle}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => openEdit(career)}
+                >
+                  편집
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() =>
+                    deleteCareer.mutate(career.id, {
+                      onSuccess: () => router.refresh(),
+                    })
+                  }
+                >
+                  삭제
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Button variant="outline" onClick={openAdd}>
+        + 경력 추가
+      </Button>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {editingCareer ? '경력 편집' : '경력 추가'}
+            </DialogTitle>
+          </DialogHeader>
+          <CareerForm
+            jobFamilies={jobFamilies}
+            onSuccess={handleSuccess}
+            careerId={editingCareer?.id}
+            initialData={editingCareer ?? undefined}
+          />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/features/profile-edit/ui/contact-form.tsx
+++ b/features/profile-edit/ui/contact-form.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from '@tanstack/react-form';
+import { profilePrivateSchema } from '@/lib/validations/profile';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { useUpdateProfilePrivate } from '../model/use-profile-mutations';
+
+type Props = {
+  initialData?: { phoneNumber?: string | null };
+};
+
+export function ContactForm({ initialData }: Props) {
+  const router = useRouter();
+  const mutation = useUpdateProfilePrivate();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const defaultValues: { phoneNumber?: string } = {
+    phoneNumber: initialData?.phoneNumber ?? undefined,
+  };
+
+  const form = useForm({
+    defaultValues,
+    validators: { onSubmit: profilePrivateSchema },
+    onSubmit: async ({ value }) => {
+      setServerError(null);
+      mutation.mutate(value, {
+        onSuccess: () => router.refresh(),
+        onError: (err) => setServerError(err.message),
+      });
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="flex flex-col gap-4"
+    >
+      <form.Field name="phoneNumber">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="contact-phone">연락처</Label>
+            <Input
+              id="contact-phone"
+              type="tel"
+              placeholder="+84 90 1234 5678"
+              value={field.state.value ?? ''}
+              onChange={(e) => field.handleChange(e.target.value || undefined)}
+              onBlur={field.handleBlur}
+            />
+            {field.state.meta.isTouched &&
+              field.state.meta.errors.length > 0 && (
+                <p className="text-xs text-destructive">
+                  {String(
+                    typeof field.state.meta.errors[0] === 'object' &&
+                      field.state.meta.errors[0] !== null
+                      ? (field.state.meta.errors[0] as { message: string })
+                          .message
+                      : field.state.meta.errors[0]
+                  )}
+                </p>
+              )}
+          </div>
+        )}
+      </form.Field>
+
+      {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+      <form.Subscribe selector={(s) => s.isSubmitting}>
+        {(isSubmitting) => (
+          <Button type="submit" disabled={isSubmitting || mutation.isPending}>
+            {isSubmitting || mutation.isPending ? '저장 중...' : '저장'}
+          </Button>
+        )}
+      </form.Subscribe>
+    </form>
+  );
+}

--- a/features/profile-edit/ui/education-form.tsx
+++ b/features/profile-edit/ui/education-form.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from '@tanstack/react-form';
+import { profileEducationSchema } from '@/lib/validations/profile';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { EDUCATION_TYPE_LABELS } from '@/entities/profile/ui/_utils';
+import {
+  useAddEducation,
+  useUpdateEducation,
+  useDeleteEducation,
+} from '../model/use-profile-mutations';
+
+type EducationData = {
+  institutionName: string;
+  educationType: string;
+  field?: string;
+  isGraduated: boolean;
+  startDate: string;
+  endDate?: string;
+  sortOrder: number;
+};
+
+type EducationFormProps = {
+  onSuccess: () => void;
+  educationId?: string;
+  initialData?: EducationData;
+};
+
+function FieldError({ errors }: { errors: unknown[] }) {
+  if (errors.length === 0) return null;
+  const msg =
+    typeof errors[0] === 'object' && errors[0] !== null
+      ? (errors[0] as { message: string }).message
+      : String(errors[0]);
+  return <p className="text-xs text-destructive">{msg}</p>;
+}
+
+export function EducationForm({
+  onSuccess,
+  educationId,
+  initialData,
+}: EducationFormProps) {
+  const addEducation = useAddEducation();
+  const updateEducation = useUpdateEducation();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const mutation = educationId ? updateEducation : addEducation;
+
+  const defaultValues: EducationData = {
+    institutionName: initialData?.institutionName ?? '',
+    educationType: initialData?.educationType ?? '',
+    field: initialData?.field ?? undefined,
+    isGraduated: initialData?.isGraduated ?? false,
+    startDate: initialData?.startDate ?? '',
+    endDate: initialData?.endDate ?? undefined,
+    sortOrder: initialData?.sortOrder ?? 0,
+  };
+
+  const form = useForm({
+    defaultValues,
+    validators: { onSubmit: profileEducationSchema },
+    onSubmit: async ({ value }) => {
+      setServerError(null);
+      const payload = value;
+      if (educationId) {
+        updateEducation.mutate(
+          { id: educationId, data: payload },
+          { onSuccess, onError: (err) => setServerError(err.message) }
+        );
+      } else {
+        addEducation.mutate(payload, {
+          onSuccess,
+          onError: (err) => setServerError(err.message),
+        });
+      }
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="flex flex-col gap-4"
+    >
+      <form.Field name="institutionName">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edu-institution">학교/기관명</Label>
+            <Input
+              id="edu-institution"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+              onBlur={field.handleBlur}
+            />
+            {field.state.meta.isTouched && (
+              <FieldError errors={field.state.meta.errors} />
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="educationType">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label>학력 유형</Label>
+            <Select
+              value={field.state.value}
+              onValueChange={field.handleChange}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="유형 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(EDUCATION_TYPE_LABELS).map(([value, label]) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {field.state.meta.isTouched && (
+              <FieldError errors={field.state.meta.errors} />
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="field">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="edu-field">전공 (선택)</Label>
+            <Input
+              id="edu-field"
+              value={field.state.value ?? ''}
+              onChange={(e) => field.handleChange(e.target.value || undefined)}
+              onBlur={field.handleBlur}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="isGraduated">
+        {(field) => (
+          <div className="flex items-center gap-2">
+            <input
+              id="edu-graduated"
+              type="checkbox"
+              checked={field.state.value}
+              onChange={(e) => field.handleChange(e.target.checked)}
+            />
+            <Label htmlFor="edu-graduated">졸업</Label>
+          </div>
+        )}
+      </form.Field>
+
+      <div className="grid grid-cols-2 gap-4">
+        <form.Field name="startDate">
+          {(field) => (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edu-start">시작일</Label>
+              <Input
+                id="edu-start"
+                type="date"
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+                onBlur={field.handleBlur}
+              />
+              {field.state.meta.isTouched && (
+                <FieldError errors={field.state.meta.errors} />
+              )}
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field name="endDate">
+          {(field) => (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edu-end">종료일 (선택)</Label>
+              <Input
+                id="edu-end"
+                type="date"
+                value={field.state.value ?? ''}
+                onChange={(e) =>
+                  field.handleChange(e.target.value || undefined)
+                }
+                onBlur={field.handleBlur}
+              />
+              {field.state.meta.isTouched && (
+                <FieldError errors={field.state.meta.errors} />
+              )}
+            </div>
+          )}
+        </form.Field>
+      </div>
+
+      {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+      <form.Subscribe selector={(s) => s.isSubmitting}>
+        {(isSubmitting) => (
+          <Button type="submit" disabled={isSubmitting || mutation.isPending}>
+            {isSubmitting || mutation.isPending ? '저장 중...' : '저장'}
+          </Button>
+        )}
+      </form.Subscribe>
+    </form>
+  );
+}
+
+type Education = EducationData & { id: string };
+
+export function EducationSection({ educations }: { educations: Education[] }) {
+  const router = useRouter();
+  const deleteEducation = useDeleteEducation();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingEducation, setEditingEducation] = useState<Education | null>(
+    null
+  );
+
+  const handleSuccess = () => {
+    setDialogOpen(false);
+    router.refresh();
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {educations.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {educations.map((edu) => (
+            <li
+              key={edu.id}
+              className="flex items-center justify-between rounded border p-3"
+            >
+              <div>
+                <p className="font-medium">{edu.institutionName}</p>
+                <p className="text-sm text-muted-foreground">
+                  {EDUCATION_TYPE_LABELS[edu.educationType] ??
+                    edu.educationType}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setEditingEducation(edu);
+                    setDialogOpen(true);
+                  }}
+                >
+                  편집
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() =>
+                    deleteEducation.mutate(edu.id, {
+                      onSuccess: () => router.refresh(),
+                    })
+                  }
+                >
+                  삭제
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Button
+        variant="outline"
+        onClick={() => {
+          setEditingEducation(null);
+          setDialogOpen(true);
+        }}
+      >
+        + 학력 추가
+      </Button>
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {editingEducation ? '학력 편집' : '학력 추가'}
+            </DialogTitle>
+          </DialogHeader>
+          <EducationForm
+            onSuccess={handleSuccess}
+            educationId={editingEducation?.id}
+            initialData={editingEducation ?? undefined}
+          />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/features/profile-edit/ui/language-form.tsx
+++ b/features/profile-edit/ui/language-form.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from '@tanstack/react-form';
+import { profileLanguageSchema } from '@/lib/validations/profile';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { PROFICIENCY_LABELS } from '@/entities/profile/ui/_utils';
+import {
+  useAddLanguage,
+  useUpdateLanguage,
+  useDeleteLanguage,
+} from '../model/use-profile-mutations';
+
+type LanguageData = {
+  language: string;
+  proficiency: string;
+  sortOrder: number;
+};
+
+type LanguageFormProps = {
+  onSuccess: () => void;
+  languageId?: string;
+  initialData?: LanguageData;
+};
+
+function FieldError({ errors }: { errors: unknown[] }) {
+  if (errors.length === 0) return null;
+  const msg =
+    errors[0] instanceof Object
+      ? (errors[0] as { message: string }).message
+      : String(errors[0]);
+  return <p className="text-xs text-destructive">{msg}</p>;
+}
+
+export function LanguageForm({
+  onSuccess,
+  languageId,
+  initialData,
+}: LanguageFormProps) {
+  const addLanguage = useAddLanguage();
+  const updateLanguage = useUpdateLanguage();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const mutation = languageId ? updateLanguage : addLanguage;
+
+  const form = useForm({
+    defaultValues: {
+      language: initialData?.language ?? '',
+      proficiency: initialData?.proficiency ?? '',
+      sortOrder: initialData?.sortOrder ?? 0,
+    },
+    validators: { onSubmit: profileLanguageSchema },
+    onSubmit: async ({ value }) => {
+      setServerError(null);
+      if (languageId) {
+        updateLanguage.mutate(
+          { id: languageId, data: value },
+          { onSuccess, onError: (err) => setServerError(err.message) }
+        );
+      } else {
+        addLanguage.mutate(value, {
+          onSuccess,
+          onError: (err) => setServerError(err.message),
+        });
+      }
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="flex flex-col gap-4"
+    >
+      <form.Field name="language">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="lang-language">언어</Label>
+            <Input
+              id="lang-language"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+              onBlur={field.handleBlur}
+            />
+            {field.state.meta.isTouched && (
+              <FieldError errors={field.state.meta.errors} />
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="proficiency">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label>숙련도</Label>
+            <Select
+              value={field.state.value}
+              onValueChange={field.handleChange}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="숙련도 선택" />
+              </SelectTrigger>
+              <SelectContent>
+                {Object.entries(PROFICIENCY_LABELS).map(([value, label]) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {field.state.meta.isTouched && (
+              <FieldError errors={field.state.meta.errors} />
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+      <form.Subscribe selector={(s) => s.isSubmitting}>
+        {(isSubmitting) => (
+          <Button type="submit" disabled={isSubmitting || mutation.isPending}>
+            {isSubmitting || mutation.isPending ? '저장 중...' : '저장'}
+          </Button>
+        )}
+      </form.Subscribe>
+    </form>
+  );
+}
+
+type Language = LanguageData & { id: string };
+
+export function LanguageSection({ languages }: { languages: Language[] }) {
+  const router = useRouter();
+  const deleteLanguage = useDeleteLanguage();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingLanguage, setEditingLanguage] = useState<Language | null>(null);
+
+  const handleSuccess = () => {
+    setDialogOpen(false);
+    router.refresh();
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {languages.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {languages.map((lang) => (
+            <li
+              key={lang.id}
+              className="flex items-center justify-between rounded border p-3"
+            >
+              <div>
+                <p className="font-medium">{lang.language}</p>
+                <p className="text-sm text-muted-foreground">
+                  {PROFICIENCY_LABELS[lang.proficiency] ?? lang.proficiency}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setEditingLanguage(lang);
+                    setDialogOpen(true);
+                  }}
+                >
+                  편집
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() =>
+                    deleteLanguage.mutate(lang.id, {
+                      onSuccess: () => router.refresh(),
+                    })
+                  }
+                >
+                  삭제
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Button
+        variant="outline"
+        onClick={() => {
+          setEditingLanguage(null);
+          setDialogOpen(true);
+        }}
+      >
+        + 언어 추가
+      </Button>
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {editingLanguage ? '언어 편집' : '언어 추가'}
+            </DialogTitle>
+          </DialogHeader>
+          <LanguageForm
+            onSuccess={handleSuccess}
+            languageId={editingLanguage?.id}
+            initialData={editingLanguage ?? undefined}
+          />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/features/profile-edit/ui/profile-public-form.tsx
+++ b/features/profile-edit/ui/profile-public-form.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from '@tanstack/react-form';
+import { profilePublicSchema } from '@/lib/validations/profile';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { useUpdateProfilePublic } from '../model/use-profile-mutations';
+
+type Props = {
+  initialData?: {
+    firstName: string;
+    lastName: string;
+    aboutMe?: string | null;
+  };
+};
+
+export function ProfilePublicForm({ initialData }: Props) {
+  const router = useRouter();
+  const mutation = useUpdateProfilePublic();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const defaultValues: {
+    firstName: string;
+    lastName: string;
+    aboutMe?: string;
+  } = {
+    firstName: initialData?.firstName ?? '',
+    lastName: initialData?.lastName ?? '',
+    aboutMe: initialData?.aboutMe ?? undefined,
+  };
+
+  const form = useForm({
+    defaultValues,
+    validators: { onSubmit: profilePublicSchema },
+    onSubmit: async ({ value }) => {
+      setServerError(null);
+      mutation.mutate(value, {
+        onSuccess: () => router.refresh(),
+        onError: (err) => setServerError(err.message),
+      });
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="flex flex-col gap-4"
+    >
+      <div className="grid grid-cols-2 gap-4">
+        <form.Field name="firstName">
+          {(field) => (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="pub-firstName">이름</Label>
+              <Input
+                id="pub-firstName"
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+                onBlur={field.handleBlur}
+              />
+              {field.state.meta.isTouched &&
+                field.state.meta.errors.length > 0 && (
+                  <p className="text-xs text-destructive">
+                    {String(
+                      typeof field.state.meta.errors[0] === 'object' &&
+                        field.state.meta.errors[0] !== null
+                        ? (field.state.meta.errors[0] as { message: string })
+                            .message
+                        : field.state.meta.errors[0]
+                    )}
+                  </p>
+                )}
+            </div>
+          )}
+        </form.Field>
+
+        <form.Field name="lastName">
+          {(field) => (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="pub-lastName">성</Label>
+              <Input
+                id="pub-lastName"
+                value={field.state.value}
+                onChange={(e) => field.handleChange(e.target.value)}
+                onBlur={field.handleBlur}
+              />
+              {field.state.meta.isTouched &&
+                field.state.meta.errors.length > 0 && (
+                  <p className="text-xs text-destructive">
+                    {String(
+                      typeof field.state.meta.errors[0] === 'object' &&
+                        field.state.meta.errors[0] !== null
+                        ? (field.state.meta.errors[0] as { message: string })
+                            .message
+                        : field.state.meta.errors[0]
+                    )}
+                  </p>
+                )}
+            </div>
+          )}
+        </form.Field>
+      </div>
+
+      <form.Field name="aboutMe">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="pub-aboutMe">소개</Label>
+            <Textarea
+              id="pub-aboutMe"
+              rows={4}
+              value={field.state.value ?? ''}
+              onChange={(e) => field.handleChange(e.target.value)}
+              onBlur={field.handleBlur}
+            />
+          </div>
+        )}
+      </form.Field>
+
+      {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+      <form.Subscribe selector={(s) => s.isSubmitting}>
+        {(isSubmitting) => (
+          <Button type="submit" disabled={isSubmitting || mutation.isPending}>
+            {isSubmitting || mutation.isPending ? '저장 중...' : '저장'}
+          </Button>
+        )}
+      </form.Subscribe>
+    </form>
+  );
+}

--- a/features/profile-edit/ui/skill-picker.tsx
+++ b/features/profile-edit/ui/skill-picker.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { searchSkills } from '@/lib/actions/catalog';
+import { useAddSkill, useDeleteSkill } from '../model/use-profile-mutations';
+
+type CurrentSkill = {
+  skill: { id: string; displayNameEn: string };
+};
+
+type SearchResult = { id: string; displayNameEn: string };
+
+export function SkillPicker({
+  currentSkills,
+}: {
+  currentSkills: CurrentSkill[];
+}) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const router = useRouter();
+  const addSkill = useAddSkill();
+  const deleteSkill = useDeleteSkill();
+
+  useEffect(() => {
+    const t = setTimeout(async () => {
+      if (!query.trim()) {
+        setResults([]);
+        return;
+      }
+      const r = await searchSkills(query);
+      if (!('error' in r)) setResults(r.data);
+    }, 300);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const currentSkillIds = new Set(currentSkills.map((s) => s.skill.id));
+  const filteredResults = results.filter((r) => !currentSkillIds.has(r.id));
+
+  return (
+    <div className="flex flex-col gap-3">
+      {currentSkills.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {currentSkills.map(({ skill }) => (
+            <span
+              key={skill.id}
+              className="flex items-center gap-1 rounded-full bg-secondary px-3 py-1 text-sm"
+            >
+              {skill.displayNameEn}
+              <button
+                type="button"
+                aria-label={`${skill.displayNameEn} 제거`}
+                className="ml-1 text-muted-foreground hover:text-foreground"
+                onClick={() =>
+                  deleteSkill.mutate(skill.id, {
+                    onSuccess: () => router.refresh(),
+                  })
+                }
+              >
+                ×
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <Input
+        placeholder="스킬 검색..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
+      {filteredResults.length > 0 && (
+        <ul className="flex flex-col rounded border">
+          {filteredResults.map((skill) => (
+            <li
+              key={skill.id}
+              className="flex items-center justify-between px-3 py-2 hover:bg-accent"
+            >
+              <span className="text-sm">{skill.displayNameEn}</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() =>
+                  addSkill.mutate(skill.id, {
+                    onSuccess: () => {
+                      setQuery('');
+                      router.refresh();
+                    },
+                  })
+                }
+              >
+                추가
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/features/profile-edit/ui/url-form.tsx
+++ b/features/profile-edit/ui/url-form.tsx
@@ -1,0 +1,208 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useForm } from '@tanstack/react-form';
+import { profileUrlSchema } from '@/lib/validations/profile';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  useAddUrl,
+  useUpdateUrl,
+  useDeleteUrl,
+} from '../model/use-profile-mutations';
+
+type UrlData = {
+  label: string;
+  url: string;
+  sortOrder: number;
+};
+
+type UrlFormProps = {
+  onSuccess: () => void;
+  urlId?: string;
+  initialData?: UrlData;
+};
+
+function FieldError({ errors }: { errors: unknown[] }) {
+  if (errors.length === 0) return null;
+  const msg =
+    errors[0] instanceof Object
+      ? (errors[0] as { message: string }).message
+      : String(errors[0]);
+  return <p className="text-xs text-destructive">{msg}</p>;
+}
+
+export function UrlForm({ onSuccess, urlId, initialData }: UrlFormProps) {
+  const addUrl = useAddUrl();
+  const updateUrl = useUpdateUrl();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const mutation = urlId ? updateUrl : addUrl;
+
+  const form = useForm({
+    defaultValues: {
+      label: initialData?.label ?? '',
+      url: initialData?.url ?? '',
+      sortOrder: initialData?.sortOrder ?? 0,
+    },
+    validators: { onSubmit: profileUrlSchema },
+    onSubmit: async ({ value }) => {
+      setServerError(null);
+      if (urlId) {
+        updateUrl.mutate(
+          { id: urlId, data: value },
+          { onSuccess, onError: (err) => setServerError(err.message) }
+        );
+      } else {
+        addUrl.mutate(value, {
+          onSuccess,
+          onError: (err) => setServerError(err.message),
+        });
+      }
+    },
+  });
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        form.handleSubmit();
+      }}
+      className="flex flex-col gap-4"
+    >
+      <form.Field name="label">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="url-label">레이블</Label>
+            <Input
+              id="url-label"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+              onBlur={field.handleBlur}
+            />
+            {field.state.meta.isTouched && (
+              <FieldError errors={field.state.meta.errors} />
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="url">
+        {(field) => (
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="url-url">URL</Label>
+            <Input
+              id="url-url"
+              type="url"
+              placeholder="https://"
+              value={field.state.value}
+              onChange={(e) => field.handleChange(e.target.value)}
+              onBlur={field.handleBlur}
+            />
+            {field.state.meta.isTouched && (
+              <FieldError errors={field.state.meta.errors} />
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+      <form.Subscribe selector={(s) => s.isSubmitting}>
+        {(isSubmitting) => (
+          <Button type="submit" disabled={isSubmitting || mutation.isPending}>
+            {isSubmitting || mutation.isPending ? '저장 중...' : '저장'}
+          </Button>
+        )}
+      </form.Subscribe>
+    </form>
+  );
+}
+
+type Url = UrlData & { id: string };
+
+export function UrlSection({ urls }: { urls: Url[] }) {
+  const router = useRouter();
+  const deleteUrl = useDeleteUrl();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingUrl, setEditingUrl] = useState<Url | null>(null);
+
+  const handleSuccess = () => {
+    setDialogOpen(false);
+    router.refresh();
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {urls.length > 0 && (
+        <ul className="flex flex-col gap-2">
+          {urls.map((u) => (
+            <li
+              key={u.id}
+              className="flex items-center justify-between rounded border p-3"
+            >
+              <div>
+                <p className="font-medium">{u.label}</p>
+                <p className="max-w-xs truncate text-sm text-muted-foreground">
+                  {u.url}
+                </p>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setEditingUrl(u);
+                    setDialogOpen(true);
+                  }}
+                >
+                  편집
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={() =>
+                    deleteUrl.mutate(u.id, {
+                      onSuccess: () => router.refresh(),
+                    })
+                  }
+                >
+                  삭제
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Button
+        variant="outline"
+        onClick={() => {
+          setEditingUrl(null);
+          setDialogOpen(true);
+        }}
+      >
+        + 링크 추가
+      </Button>
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{editingUrl ? '링크 편집' : '링크 추가'}</DialogTitle>
+          </DialogHeader>
+          <UrlForm
+            onSuccess={handleSuccess}
+            urlId={editingUrl?.id}
+            initialData={editingUrl ?? undefined}
+          />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "better-auth": "^1.4.18",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.563.0",
     "next": "16.1.6",
     "pg": "^8.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      cmdk:
+        specifier: ^1.1.1
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.3)
@@ -3762,6 +3765,12 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmdk@1.1.1:
+    resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -11720,6 +11729,18 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.13)(react@19.2.3)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.13)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   co@4.6.0: {}
 


### PR DESCRIPTION
## 개요

프로필 편집 FSD feature 레이어를 구현합니다. 기존 16개 서버 액션을 TanStack Query useMutation으로 래핑하고, 각 프로필 섹션별 편집 폼 컴포넌트를 추가합니다.

## 변경 사항

- **뮤테이션 훅** (`features/profile-edit/model/use-profile-mutations.ts`): 16개 서버 액션 래핑
- **폼 컴포넌트** (`features/profile-edit/ui/`):
  - `ProfilePublicForm`: 이름/소개
  - `ContactForm`: 연락처
  - `CareerForm` + `CareerSection`: 경력 CRUD (Dialog)
  - `EducationForm` + `EducationSection`: 학력 CRUD (Dialog)
  - `LanguageForm` + `LanguageSection`: 언어 CRUD (Dialog)
  - `UrlForm` + `UrlSection`: 링크 CRUD (Dialog)
  - `SkillPicker`: 디바운스 검색 + 스킬 추가/삭제
- **편집 페이지** (`app/(dashboard)/candidate/profile/edit/page.tsx`): RSC, 모든 폼 카드로 구성
- **shadcn 컴포넌트**: select, textarea, command, popover 추가
- **테스트**: career-form, skill-picker 단위 테스트 (179개 통과)

## 테스트 계획

- [ ] `pnpm test` — 179개 통과 확인
- [ ] `pnpm tsc --noEmit` — 타입 오류 없음 확인
- [ ] `/dashboard/candidate/profile/edit` 수동 접속
- [ ] 경력 추가/편집/삭제 동작 확인
- [ ] 스킬 검색 및 추가/삭제 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)