### PR TITLE
Prompt 21 후속: Jobs 정렬 및 쿼리 상태 일관성 구현

### DIFF
--- a/__tests__/features/job-browse/job-category-tabs.test.tsx
+++ b/__tests__/features/job-browse/job-category-tabs.test.tsx
@@ -8,24 +8,30 @@ const families = [
 
 describe('JobCategoryTabs', () => {
   it('"All" 탭이 항상 렌더링된다', () => {
-    render(<JobCategoryTabs families={families} />);
+    render(<JobCategoryTabs families={families} query={{}} />);
     expect(screen.getByText('All')).toBeInTheDocument();
   });
 
   it('패밀리 이름이 모두 렌더링된다', () => {
-    render(<JobCategoryTabs families={families} />);
+    render(<JobCategoryTabs families={families} query={{}} />);
     expect(screen.getByText('Engineering')).toBeInTheDocument();
     expect(screen.getByText('Design')).toBeInTheDocument();
   });
 
   it('activeFamilyId 미전달 시 "All" 탭이 활성 상태', () => {
-    render(<JobCategoryTabs families={families} />);
+    render(<JobCategoryTabs families={families} query={{}} />);
     const allTab = screen.getByText('All').closest('a');
     expect(allTab?.className).toContain('ff6000');
   });
 
   it('activeFamilyId 전달 시 해당 탭이 활성 상태', () => {
-    render(<JobCategoryTabs families={families} activeFamilyId="design" />);
+    render(
+      <JobCategoryTabs
+        families={families}
+        activeFamilyId="design"
+        query={{ search: 'react', sort: 'created_desc', page: 3 }}
+      />
+    );
     const designTab = screen.getByText('Design').closest('a');
     expect(designTab?.className).toContain('ff6000');
 
@@ -34,14 +40,35 @@ describe('JobCategoryTabs', () => {
   });
 
   it('탭 href에 familyId가 포함된다', () => {
-    render(<JobCategoryTabs families={families} />);
+    render(
+      <JobCategoryTabs
+        families={families}
+        query={{ search: 'react', sort: 'created_desc', page: 3 }}
+      />
+    );
     const engLink = screen.getByText('Engineering').closest('a');
-    expect(engLink).toHaveAttribute('href', '/jobs?familyId=engineering');
+    expect(engLink).toHaveAttribute(
+      'href',
+      '/jobs?search=react&familyId=engineering&sort=created_desc'
+    );
   });
 
-  it('"All" 탭 href는 /jobs', () => {
-    render(<JobCategoryTabs families={families} />);
+  it('"All" 탭 href는 search/sort 유지 + familyId/page 제거', () => {
+    render(
+      <JobCategoryTabs
+        families={families}
+        query={{
+          search: 'react',
+          familyId: 'design',
+          sort: 'created_desc',
+          page: 3,
+        }}
+      />
+    );
     const allLink = screen.getByText('All').closest('a');
-    expect(allLink).toHaveAttribute('href', '/jobs');
+    expect(allLink).toHaveAttribute(
+      'href',
+      '/jobs?search=react&sort=created_desc'
+    );
   });
 });

--- a/__tests__/features/job-browse/job-search-form.test.tsx
+++ b/__tests__/features/job-browse/job-search-form.test.tsx
@@ -2,12 +2,17 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { JobSearchForm } from '@/features/job-browse/ui/job-search-form';
 
 const mockPush = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(() => ({ push: mockPush })),
-  useSearchParams: jest.fn(() => new URLSearchParams()),
+  useSearchParams: jest.fn(() => mockSearchParams),
 }));
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSearchParams = new URLSearchParams();
+});
 
 describe('JobSearchForm', () => {
   it('SearchBar를 렌더링한다', () => {
@@ -36,5 +41,18 @@ describe('JobSearchForm', () => {
     fireEvent.submit(screen.getByRole('form'));
 
     expect(mockPush).toHaveBeenCalledWith('/jobs');
+  });
+
+  it('제출 시 familyId, sort 유지 + page 제거', () => {
+    mockSearchParams = new URLSearchParams(
+      'familyId=engineering&sort=created_desc&page=3'
+    );
+
+    render(<JobSearchForm initialSearch="백엔드" />);
+    fireEvent.submit(screen.getByRole('form'));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      '/jobs?search=%EB%B0%B1%EC%97%94%EB%93%9C&familyId=engineering&sort=created_desc'
+    );
   });
 });

--- a/__tests__/features/job-browse/job-sort-control.test.tsx
+++ b/__tests__/features/job-browse/job-sort-control.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { JobSortControl } from '@/features/job-browse/ui/job-sort-control';
+
+const mockPush = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({ push: mockPush })),
+  useSearchParams: jest.fn(() => mockSearchParams),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSearchParams = new URLSearchParams();
+});
+
+describe('JobSortControl', () => {
+  it('정렬 컨트롤을 렌더링한다', () => {
+    render(<JobSortControl />);
+    expect(screen.getByText('Sort by:')).toBeInTheDocument();
+    expect(
+      screen.getByRole('combobox', { name: 'Sort by' })
+    ).toBeInTheDocument();
+  });
+
+  it('sort 파라미터 없으면 기본값 updated_desc 선택', () => {
+    render(<JobSortControl />);
+    const select = screen.getByRole('combobox', { name: 'Sort by' });
+    expect(select).toHaveValue('updated_desc');
+  });
+
+  it('created_desc 선택 시 search/familyId 유지 + page 제거', () => {
+    mockSearchParams = new URLSearchParams(
+      'search=react&familyId=engineering&page=3'
+    );
+
+    render(<JobSortControl />);
+    const select = screen.getByRole('combobox', { name: 'Sort by' });
+    fireEvent.change(select, { target: { value: 'created_desc' } });
+
+    expect(mockPush).toHaveBeenCalledWith(
+      '/jobs?search=react&familyId=engineering&sort=created_desc'
+    );
+  });
+
+  it('updated_desc 선택 시 sort/page 제거', () => {
+    mockSearchParams = new URLSearchParams(
+      'search=react&familyId=engineering&sort=created_desc&page=2'
+    );
+
+    render(<JobSortControl />);
+    const select = screen.getByRole('combobox', { name: 'Sort by' });
+    fireEvent.change(select, { target: { value: 'updated_desc' } });
+
+    expect(mockPush).toHaveBeenCalledWith(
+      '/jobs?search=react&familyId=engineering'
+    );
+  });
+});

--- a/__tests__/features/job-browse/query-state.test.ts
+++ b/__tests__/features/job-browse/query-state.test.ts
@@ -1,0 +1,83 @@
+import {
+  DEFAULT_JOBS_SORT,
+  applyJobsQueryPatch,
+  buildJobsHref,
+  getEffectiveJobsSort,
+  parseJobsQueryFromRecord,
+  parseJobsQueryFromSearchParams,
+} from '@/features/job-browse/model/query-state';
+
+describe('jobs query-state helpers', () => {
+  it('record 파싱: known key만 파싱 + page/sort 정규화', () => {
+    const parsed = parseJobsQueryFromRecord({
+      search: '  react  ',
+      familyId: 'engineering',
+      sort: 'created_desc',
+      page: '3',
+      unknown: 'x',
+    });
+
+    expect(parsed).toEqual({
+      search: 'react',
+      familyId: 'engineering',
+      sort: 'created_desc',
+      page: 3,
+    });
+  });
+
+  it('searchParams 파싱: 잘못된 sort/page는 제거', () => {
+    const parsed = parseJobsQueryFromSearchParams(
+      new URLSearchParams('search=vue&sort=latest&page=abc')
+    );
+
+    expect(parsed).toEqual({ search: 'vue' });
+  });
+
+  it('getEffectiveJobsSort: 기본값 보정', () => {
+    expect(getEffectiveJobsSort({})).toBe(DEFAULT_JOBS_SORT);
+    expect(getEffectiveJobsSort({ sort: 'created_desc' })).toBe('created_desc');
+  });
+
+  it('applyJobsQueryPatch: resetPage=true면 page 제거', () => {
+    const next = applyJobsQueryPatch(
+      {
+        search: 'react',
+        familyId: 'engineering',
+        sort: 'created_desc',
+        page: 4,
+      },
+      { familyId: 'design' },
+      { resetPage: true }
+    );
+
+    expect(next).toEqual({
+      search: 'react',
+      familyId: 'design',
+      sort: 'created_desc',
+    });
+  });
+
+  it('buildJobsHref: 기본 정렬/1페이지는 URL에서 생략', () => {
+    const href = buildJobsHref({
+      search: 'react',
+      familyId: 'engineering',
+      sort: 'updated_desc',
+      page: 1,
+    });
+
+    expect(href).toBe('/jobs?search=react&familyId=engineering');
+  });
+
+  it('buildJobsHref: created_desc와 page>1은 유지', () => {
+    const href = buildJobsHref({
+      search: 'react',
+      familyId: 'engineering',
+      sort: 'created_desc',
+      page: 2,
+    });
+
+    expect(href).toBe(
+      '/jobs?search=react&familyId=engineering&sort=created_desc&page=2'
+    );
+  });
+});

--- a/__tests__/lib/actions/jd-queries.test.ts
+++ b/__tests__/lib/actions/jd-queries.test.ts
@@ -24,12 +24,17 @@ describe('getJobDescriptions', () => {
       mockResult
     );
 
-    const result = await getJobDescriptions({ page: 1, pageSize: 20 });
+    const result = await getJobDescriptions({
+      page: 1,
+      pageSize: 20,
+      sort: 'updated_desc',
+    });
 
     expect(result).toEqual({ success: true, data: mockResult });
     expect(jdQueriesUC.getJobDescriptions).toHaveBeenCalledWith({
       page: 1,
       pageSize: 20,
+      sort: 'updated_desc',
     });
   });
 
@@ -69,8 +74,44 @@ describe('getJobDescriptions', () => {
 
     expect(result).toEqual(expect.objectContaining({ success: true }));
     expect(jdQueriesUC.getJobDescriptions).toHaveBeenCalledWith(
-      expect.objectContaining({ page: 1, pageSize: 20 })
+      expect.objectContaining({
+        page: 1,
+        pageSize: 20,
+        sort: 'updated_desc',
+      })
     );
+  });
+
+  it('sort 파라미터가 use-case에 전달됨', async () => {
+    (jdQueriesUC.getJobDescriptions as unknown as jest.Mock).mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+
+    await getJobDescriptions({
+      sort: 'created_desc',
+      page: 1,
+      pageSize: 20,
+    });
+
+    expect(jdQueriesUC.getJobDescriptions).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: 'created_desc' })
+    );
+  });
+
+  it('유효하지 않은 sort 값은 거부', async () => {
+    const result = await getJobDescriptions({
+      sort: 'oldest',
+      page: 1,
+      pageSize: 20,
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({ error: expect.any(String) })
+    );
+    expect(jdQueriesUC.getJobDescriptions).not.toHaveBeenCalled();
   });
 });
 

--- a/__tests__/lib/use-cases/jd-queries.test.ts
+++ b/__tests__/lib/use-cases/jd-queries.test.ts
@@ -43,6 +43,7 @@ describe('getJobDescriptions', () => {
     const result = await getJobDescriptions({
       page: 1,
       pageSize: 20,
+      sort: 'updated_desc',
     });
 
     expect(result).toEqual({
@@ -56,7 +57,7 @@ describe('getJobDescriptions', () => {
         where: {},
         skip: 0,
         take: 20,
-        orderBy: { createdAt: 'desc' },
+        orderBy: [{ updatedAt: 'desc' }, { id: 'desc' }],
       })
     );
   });
@@ -68,6 +69,7 @@ describe('getJobDescriptions', () => {
       workArrangement: 'remote',
       page: 1,
       pageSize: 20,
+      sort: 'updated_desc',
     });
 
     expect(prisma.jobDescription.findMany).toHaveBeenCalledWith(
@@ -86,6 +88,7 @@ describe('getJobDescriptions', () => {
       jobId: 'frontend',
       page: 1,
       pageSize: 20,
+      sort: 'updated_desc',
     });
 
     const callArg = (prisma.jobDescription.findMany as unknown as jest.Mock)
@@ -99,6 +102,7 @@ describe('getJobDescriptions', () => {
       search: '프론트엔드',
       page: 1,
       pageSize: 20,
+      sort: 'updated_desc',
     });
 
     const callArg = (prisma.jobDescription.findMany as unknown as jest.Mock)
@@ -114,6 +118,7 @@ describe('getJobDescriptions', () => {
       familyId: 'engineering',
       page: 1,
       pageSize: 20,
+      sort: 'updated_desc',
     });
 
     const callArg = (prisma.jobDescription.findMany as unknown as jest.Mock)
@@ -122,7 +127,7 @@ describe('getJobDescriptions', () => {
   });
 
   it('search, familyId 미전달 시 where에 포함되지 않음', async () => {
-    await getJobDescriptions({ page: 1, pageSize: 20 });
+    await getJobDescriptions({ page: 1, pageSize: 20, sort: 'updated_desc' });
 
     const callArg = (prisma.jobDescription.findMany as unknown as jest.Mock)
       .mock.calls[0][0];
@@ -131,7 +136,7 @@ describe('getJobDescriptions', () => {
   });
 
   it('page 2 — skip: pageSize', async () => {
-    await getJobDescriptions({ page: 2, pageSize: 10 });
+    await getJobDescriptions({ page: 2, pageSize: 10, sort: 'updated_desc' });
 
     expect(prisma.jobDescription.findMany).toHaveBeenCalledWith(
       expect.objectContaining({ skip: 10, take: 10 })
@@ -141,11 +146,29 @@ describe('getJobDescriptions', () => {
   it('{ items, total, page, pageSize } 형태 반환', async () => {
     (prisma.jobDescription.count as unknown as jest.Mock).mockResolvedValue(42);
 
-    const result = await getJobDescriptions({ page: 3, pageSize: 5 });
+    const result = await getJobDescriptions({
+      page: 3,
+      pageSize: 5,
+      sort: 'updated_desc',
+    });
 
     expect(result.total).toBe(42);
     expect(result.page).toBe(3);
     expect(result.pageSize).toBe(5);
+  });
+
+  it('sort=created_desc면 createdAt 기준 정렬', async () => {
+    await getJobDescriptions({
+      page: 1,
+      pageSize: 20,
+      sort: 'created_desc',
+    });
+
+    expect(prisma.jobDescription.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      })
+    );
   });
 });
 

--- a/__tests__/lib/validations/job-description.test.ts
+++ b/__tests__/lib/validations/job-description.test.ts
@@ -53,4 +53,24 @@ describe('jobDescriptionFilterSchema', () => {
     expect(result.search).toBeUndefined();
     expect(result.familyId).toBeUndefined();
   });
+
+  it('sort 기본값은 updated_desc', () => {
+    const result = jobDescriptionFilterSchema.parse({});
+    expect(result.sort).toBe('updated_desc');
+  });
+
+  it('sort 값으로 updated_desc, created_desc 허용', () => {
+    expect(
+      jobDescriptionFilterSchema.safeParse({ sort: 'updated_desc' }).success
+    ).toBe(true);
+    expect(
+      jobDescriptionFilterSchema.safeParse({ sort: 'created_desc' }).success
+    ).toBe(true);
+  });
+
+  it('잘못된 sort 값 거부', () => {
+    expect(
+      jobDescriptionFilterSchema.safeParse({ sort: 'oldest' }).success
+    ).toBe(false);
+  });
 });

--- a/docs/implementation-plan-p5.md
+++ b/docs/implementation-plan-p5.md
@@ -220,6 +220,21 @@ P24 (Polish + E2E) depends on all
 - 중복 제거: /candidate/jobs 라우트 삭제, JdFilters 삭제, 인라인 PaginationRow/mapJd 삭제
 - 377개 테스트 통과 (52 suite), `tsc --noEmit` 클린
 
+#### Prompt 21 후속 작업
+
+- Jobs 목록 정렬 UI를 추가하고(`Recent updated`, `Recent posted`), `getJobDescriptions` 및 `jobDescriptionFilterSchema`에 정렬 파라미터(`sort`)를 연결한다.
+- 검색/카테고리/정렬/페이지네이션이 URL 쿼리 상태(`search`, `familyId`, `sort`, `page`)를 일관되게 보존하도록 쿼리 상태 헬퍼를 도입한다.
+
+#### Prompt 21 results
+
+- Jobs 목록 정렬 기능을 추가하고 기본 정렬을 `Recent updated`(`updated_desc`)로 설정했다.
+- `sort` 파라미터를 검증 스키마(`jobDescriptionFilterSchema`)와 조회 use-case(`getJobDescriptions`)에 연결했다.
+- 정렬 기준별 DB 정렬을 적용했다: `updated_desc`(`updatedAt DESC`), `created_desc`(`createdAt DESC`) + `id DESC` tie-breaker.
+- jobs query-state 헬퍼(`features/job-browse/model/query-state.ts`)를 추가해 `search`/`familyId`/`sort`/`page` 병합 규칙을 중앙화했다.
+- 검색/카테고리/정렬/페이지네이션 간 URL 상태 보존 문제를 수정해 상호 동작 일관성을 확보했다.
+- 테스트를 확장했다: query-state 유닛 테스트, sort-control 테스트, jobs 관련 validation/action/use-case/UI 테스트 업데이트.
+- 전체 검증 완료: `59 suite`, `408 tests`, `tsc --noEmit` 클린.
+
 ---
 
 ## Prompt 22: Profile View + Edit Redesign
@@ -312,6 +327,20 @@ P24 (Polish + E2E) depends on all
 - Authorization checks
 
 **Build verification**: `pnpm build` + `pnpm lint` + `tsc --noEmit` all clean.
+
+**Frontend architecture polish (FSD alignment):**
+
+- Remove cross-entity coupling by moving shared UI labels/formatters out of entity-internal utils and into a shared frontend module, then update imports in `entities/job`, `entities/application`, `features/profile-edit`, and dashboard pages.
+- Centralize jobs query-state handling in `features/job-browse/model` (single parse/build policy for `search`, `familyId`, `sort`, `page`) and reuse it across search form, category tabs, sort control, and pagination.
+- Add lint-based layer guardrails (e.g., `no-restricted-imports`) to enforce FSD dependency direction and prevent future cross-layer leaks.
+- Reconcile architecture docs (`docs/folder-structure.md`) with the actual current structure and ownership boundaries.
+
+**Polish acceptance criteria (FSD):**
+
+- No imports from `entities/profile/ui/_utils` outside the profile entity slice.
+- Jobs browse controls preserve query state consistently under one shared policy.
+- ESLint catches prohibited cross-layer imports in CI.
+- Folder-structure documentation matches real code paths and slice responsibilities.
 
 ---
 

--- a/features/job-browse/model/query-state.ts
+++ b/features/job-browse/model/query-state.ts
@@ -1,0 +1,102 @@
+export const DEFAULT_JOBS_SORT = 'updated_desc' as const;
+export const JOBS_SORT_VALUES = ['updated_desc', 'created_desc'] as const;
+
+export type JobsSort = (typeof JOBS_SORT_VALUES)[number];
+
+export type JobsQueryState = {
+  search?: string;
+  familyId?: string;
+  sort?: JobsSort;
+  page?: number;
+};
+
+function isJobsSort(value: string | undefined): value is JobsSort {
+  return !!value && (JOBS_SORT_VALUES as readonly string[]).includes(value);
+}
+
+function normalizeText(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function parsePositiveInt(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const num = Number(value);
+  if (!Number.isInteger(num) || num < 1) return undefined;
+  return num;
+}
+
+function sanitizeQuery(query: JobsQueryState): JobsQueryState {
+  return {
+    search: normalizeText(query.search),
+    familyId: normalizeText(query.familyId),
+    sort: isJobsSort(query.sort) ? query.sort : undefined,
+    page:
+      query.page !== undefined && Number.isInteger(query.page) && query.page > 0
+        ? query.page
+        : undefined,
+  };
+}
+
+function getSingleRecordValue(
+  value: string | string[] | undefined
+): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+export function parseJobsQueryFromRecord(
+  params: Record<string, string | string[] | undefined>
+): JobsQueryState {
+  return sanitizeQuery({
+    search: getSingleRecordValue(params.search),
+    familyId: getSingleRecordValue(params.familyId),
+    sort: getSingleRecordValue(params.sort) as JobsSort | undefined,
+    page: parsePositiveInt(getSingleRecordValue(params.page)),
+  });
+}
+
+export function parseJobsQueryFromSearchParams(
+  params: URLSearchParams
+): JobsQueryState {
+  return sanitizeQuery({
+    search: params.get('search') ?? undefined,
+    familyId: params.get('familyId') ?? undefined,
+    sort: (params.get('sort') ?? undefined) as JobsSort | undefined,
+    page: parsePositiveInt(params.get('page') ?? undefined),
+  });
+}
+
+export function getEffectiveJobsSort(query: JobsQueryState): JobsSort {
+  return query.sort ?? DEFAULT_JOBS_SORT;
+}
+
+export function applyJobsQueryPatch(
+  current: JobsQueryState,
+  patch: Partial<JobsQueryState>,
+  options?: { resetPage?: boolean }
+): JobsQueryState {
+  const merged = sanitizeQuery({ ...current, ...patch });
+  if (options?.resetPage) {
+    delete merged.page;
+  }
+  return merged;
+}
+
+export function buildJobsHref(query: JobsQueryState): string {
+  const normalized = sanitizeQuery(query);
+  const params = new URLSearchParams();
+
+  if (normalized.search) params.set('search', normalized.search);
+  if (normalized.familyId) params.set('familyId', normalized.familyId);
+  if (normalized.sort && normalized.sort !== DEFAULT_JOBS_SORT) {
+    params.set('sort', normalized.sort);
+  }
+  if (normalized.page && normalized.page > 1) {
+    params.set('page', String(normalized.page));
+  }
+
+  const qs = params.toString();
+  return qs ? `/jobs?${qs}` : '/jobs';
+}

--- a/features/job-browse/ui/job-category-tabs.tsx
+++ b/features/job-browse/ui/job-category-tabs.tsx
@@ -1,22 +1,34 @@
 'use client';
 
 import { TabItem } from '@/components/ui/tab-item';
+import {
+  applyJobsQueryPatch,
+  buildJobsHref,
+  type JobsQueryState,
+} from '@/features/job-browse/model/query-state';
 
 type Props = {
   families: { id: string; displayNameEn: string }[];
   activeFamilyId?: string;
+  query: JobsQueryState;
 };
 
-export function JobCategoryTabs({ families, activeFamilyId }: Props) {
+export function JobCategoryTabs({ families, activeFamilyId, query }: Props) {
+  const allHref = buildJobsHref(
+    applyJobsQueryPatch(query, { familyId: undefined }, { resetPage: true })
+  );
+
   return (
     <div className="flex gap-2">
-      <TabItem label="All" isActive={!activeFamilyId} href="/jobs" />
+      <TabItem label="All" isActive={!activeFamilyId} href={allHref} />
       {families.map((f) => (
         <TabItem
           key={f.id}
           label={f.displayNameEn}
           isActive={activeFamilyId === f.id}
-          href={`/jobs?familyId=${f.id}`}
+          href={buildJobsHref(
+            applyJobsQueryPatch(query, { familyId: f.id }, { resetPage: true })
+          )}
         />
       ))}
     </div>

--- a/features/job-browse/ui/job-search-form.tsx
+++ b/features/job-browse/ui/job-search-form.tsx
@@ -3,6 +3,11 @@
 import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { SearchBar } from '@/components/ui/search-bar';
+import {
+  applyJobsQueryPatch,
+  buildJobsHref,
+  parseJobsQueryFromSearchParams,
+} from '@/features/job-browse/model/query-state';
 
 type Props = {
   initialSearch?: string;
@@ -15,12 +20,13 @@ export function JobSearchForm({ initialSearch = '' }: Props) {
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const params = new URLSearchParams();
-    const familyId = searchParams.get('familyId');
-    if (familyId) params.set('familyId', familyId);
-    if (value.trim()) params.set('search', value.trim());
-    const qs = params.toString();
-    router.push(qs ? `/jobs?${qs}` : '/jobs');
+    const query = parseJobsQueryFromSearchParams(searchParams);
+    const nextQuery = applyJobsQueryPatch(
+      query,
+      { search: value.trim() || undefined },
+      { resetPage: true }
+    );
+    router.push(buildJobsHref(nextQuery));
   }
 
   return (

--- a/features/job-browse/ui/job-sort-control.tsx
+++ b/features/job-browse/ui/job-sort-control.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Icon } from '@/components/ui/icon';
+import {
+  applyJobsQueryPatch,
+  buildJobsHref,
+  getEffectiveJobsSort,
+  parseJobsQueryFromSearchParams,
+  type JobsSort,
+} from '@/features/job-browse/model/query-state';
+
+const SORT_OPTIONS: { value: JobsSort; label: string }[] = [
+  { value: 'updated_desc', label: 'Recent updated' },
+  { value: 'created_desc', label: 'Recent posted' },
+];
+
+export function JobSortControl() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const query = parseJobsQueryFromSearchParams(searchParams);
+  const currentSort = getEffectiveJobsSort(query);
+
+  function handleChange(nextSort: JobsSort) {
+    const nextQuery = applyJobsQueryPatch(
+      query,
+      {
+        sort: nextSort,
+      },
+      { resetPage: true }
+    );
+    router.push(buildJobsHref(nextQuery));
+  }
+
+  return (
+    <div className="flex items-center gap-[5px] rounded-md px-2.5 py-2 shadow-[0px_4px_4px_0px_rgba(0,0,0,0.07)]">
+      <span className="text-xs text-black">Sort by:</span>
+      <div className="relative">
+        <select
+          aria-label="Sort by"
+          value={currentSort}
+          onChange={(e) => handleChange(e.target.value as JobsSort)}
+          className="appearance-none bg-transparent pr-4 text-xs text-black underline"
+        >
+          {SORT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <span className="pointer-events-none absolute top-1/2 right-0 -translate-y-1/2">
+          <Icon name="chevron-down" size={12} />
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/lib/use-cases/jd-queries.ts
+++ b/lib/use-cases/jd-queries.ts
@@ -19,6 +19,7 @@ export async function getJobDescriptions(
     workArrangement,
     search,
     familyId,
+    sort,
     page,
     pageSize,
   } = filters;
@@ -30,11 +31,16 @@ export async function getJobDescriptions(
   if (search) where.title = { contains: search, mode: 'insensitive' };
   if (familyId) where.job = { is: { jobFamilyId: familyId } };
 
+  const orderBy =
+    sort === 'created_desc'
+      ? [{ createdAt: 'desc' as const }, { id: 'desc' as const }]
+      : [{ updatedAt: 'desc' as const }, { id: 'desc' as const }];
+
   const [items, total] = await Promise.all([
     prisma.jobDescription.findMany({
       where,
       include: JD_INCLUDE,
-      orderBy: { createdAt: 'desc' },
+      orderBy,
       skip: (page - 1) * pageSize,
       take: pageSize,
     }),

--- a/lib/validations/job-description.ts
+++ b/lib/validations/job-description.ts
@@ -8,6 +8,7 @@ export const jobDescriptionFilterSchema = z.object({
   workArrangement: z.enum(['onsite', 'hybrid', 'remote']).optional(),
   search: z.string().optional(),
   familyId: z.string().optional(),
+  sort: z.enum(['updated_desc', 'created_desc']).default('updated_desc'),
   page: z.number().int().min(1).default(1),
   pageSize: z.number().int().min(1).max(50).default(20),
 });

--- a/todo.md
+++ b/todo.md
@@ -79,6 +79,6 @@
 
 ## 현재 상태
 
-- **테스트**: 391개 통과 (57 suite)
+- **테스트**: 408개 통과 (59 suite)
 - **타입 체크**: `tsc --noEmit` 클린
-- **브랜치**: `feat/prompt22`
+- **브랜치**: `feat/prompt21-sort-query-state`


### PR DESCRIPTION
## 구현 내용
- Jobs 목록 정렬 옵션(Recent updated, Recent posted) 추가 및 sort 파라미터를 검증/조회 로직에 연결했습니다.
- updated_desc, created_desc 기준 DB 정렬과 id DESC tie-breaker를 적용했습니다.
- features/job-browse/model/query-state.ts를 도입해 search/familyId/sort/page 병합 정책을 중앙화했습니다.
- 검색/카테고리/정렬/페이지네이션 간 쿼리 상태 보존과 page reset 규칙을 일관되게 반영했습니다.
- Prompt 21 결과를 docs/implementation-plan-p5.md와 todo.md에 반영했습니다.

## 변경 파일
- 총 16개 파일 (신규 4, 수정 12)
- 핵심 변경: app/jobs/page.tsx, lib/validations/job-description.ts, lib/use-cases/jd-queries.ts, features/job-browse/model/query-state.ts, features/job-browse/ui/job-search-form.tsx, features/job-browse/ui/job-category-tabs.tsx, features/job-browse/ui/job-sort-control.tsx
- 테스트/문서 변경: jobs 관련 테스트 7개 파일, docs/implementation-plan-p5.md, todo.md

## 테스트 결과
- pnpm test: 59 suite, 408 tests 통과
- pnpm tsc --noEmit: 통과