### PR TITLE
feat: Prompt 23 공지사항/후보자 슬러그 페이지 구현

### DIFF
--- a/__tests__/app/announcement-detail-page.test.tsx
+++ b/__tests__/app/announcement-detail-page.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import AnnouncementDetailPage from '@/app/announcements/[id]/page';
+import {
+  getAnnouncementById,
+  getAnnouncementNeighbors,
+} from '@/lib/actions/announcements';
+
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+jest.mock('@/lib/actions/announcements', () => ({
+  getAnnouncementById: jest.fn(),
+  getAnnouncementNeighbors: jest.fn(),
+}));
+
+const mockGetAnnouncementById = getAnnouncementById as unknown as jest.Mock;
+const mockGetAnnouncementNeighbors =
+  getAnnouncementNeighbors as unknown as jest.Mock;
+
+describe('AnnouncementDetailPage', () => {
+  it('상세/핀/Next-Before 영역을 렌더링한다', async () => {
+    mockGetAnnouncementById.mockResolvedValue({
+      success: true,
+      data: {
+        id: 'ann-1',
+        title: 'About Vridge',
+        content: '안내 본문',
+        isPinned: true,
+        createdAt: new Date('2026-02-06T00:00:00.000Z'),
+        updatedAt: new Date('2026-02-06T00:00:00.000Z'),
+      },
+    });
+    mockGetAnnouncementNeighbors.mockResolvedValue({
+      success: true,
+      data: {
+        next: {
+          id: 'ann-2',
+          title: '다음 공지',
+          isPinned: false,
+          createdAt: new Date('2026-03-18T00:00:00.000Z'),
+        },
+        before: {
+          id: 'ann-0',
+          title: '이전 공지',
+          isPinned: false,
+          createdAt: new Date('2026-02-14T00:00:00.000Z'),
+        },
+      },
+    });
+
+    const ui = await AnnouncementDetailPage({
+      params: Promise.resolve({ id: 'ann-1' }),
+    });
+    render(ui);
+
+    expect(screen.getByText('About Vridge')).toBeInTheDocument();
+    expect(screen.getByText('(Pinned)')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '다음 공지' })).toHaveAttribute(
+      'href',
+      '/announcements/ann-2'
+    );
+    expect(screen.getByRole('link', { name: '이전 공지' })).toHaveAttribute(
+      'href',
+      '/announcements/ann-0'
+    );
+    expect(
+      screen.getByRole('link', { name: /announcement 목록/i })
+    ).toHaveAttribute('href', '/announcements');
+  });
+});

--- a/__tests__/app/announcements-page.test.tsx
+++ b/__tests__/app/announcements-page.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import AnnouncementsPage from '@/app/announcements/page';
+import { getAnnouncements } from '@/lib/actions/announcements';
+
+jest.mock('@/lib/actions/announcements', () => ({
+  getAnnouncements: jest.fn(),
+}));
+
+const mockGetAnnouncements = getAnnouncements as unknown as jest.Mock;
+
+describe('AnnouncementsPage', () => {
+  it('공지 목록과 번호/핀 표시를 렌더링한다', async () => {
+    mockGetAnnouncements.mockResolvedValue({
+      success: true,
+      data: {
+        items: [
+          {
+            id: 'ann-pinned',
+            title: '핀 공지',
+            content: '내용',
+            isPinned: true,
+            createdAt: new Date('2026-02-06T00:00:00.000Z'),
+            updatedAt: new Date('2026-02-06T00:00:00.000Z'),
+          },
+          {
+            id: 'ann-normal',
+            title: '일반 공지',
+            content: '내용',
+            isPinned: false,
+            createdAt: new Date('2026-02-05T00:00:00.000Z'),
+            updatedAt: new Date('2026-02-05T00:00:00.000Z'),
+          },
+        ],
+        total: 10,
+        page: 1,
+        pageSize: 20,
+      },
+    });
+
+    const ui = await AnnouncementsPage({
+      searchParams: Promise.resolve({ page: '1' }),
+    });
+    render(ui);
+
+    expect(screen.getByText('Announcement')).toBeInTheDocument();
+    expect(screen.getByText('📍')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '일반 공지' })).toHaveAttribute(
+      'href',
+      '/announcements/ann-normal'
+    );
+    expect(screen.getByText('9')).toBeInTheDocument();
+  });
+});

--- a/__tests__/app/candidate-applications-page.test.tsx
+++ b/__tests__/app/candidate-applications-page.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import MyApplicationsPage from '@/app/(dashboard)/candidate/applications/page';
+import { requireUser } from '@/lib/infrastructure/auth-utils';
+import { getMyApplications } from '@/lib/actions/applications';
+
+jest.mock('@/lib/infrastructure/auth-utils', () => ({
+  requireUser: jest.fn(),
+  getCurrentUser: jest.fn(),
+  requireRole: jest.fn(),
+}));
+jest.mock('@/lib/actions/applications', () => ({
+  getMyApplications: jest.fn(),
+}));
+
+const mockRequireUser = requireUser as unknown as jest.Mock;
+const mockGetMyApplications = getMyApplications as unknown as jest.Mock;
+
+describe('MyApplicationsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireUser.mockResolvedValue({
+      userId: 'candidate-1',
+      role: 'candidate',
+      email: 'candidate@vridge.net',
+      orgId: null,
+    });
+  });
+
+  it('요약 통계와 지원 목록을 렌더링한다', async () => {
+    mockGetMyApplications.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 'apply-1',
+          jdId: 'jd-1',
+          status: 'applied',
+          createdAt: new Date('2026-02-01T00:00:00.000Z'),
+          jd: {
+            id: 'jd-1',
+            title: 'Product Designer',
+            employmentType: 'full_time',
+            workArrangement: 'onsite',
+            org: { name: 'Flowbit' },
+            job: {
+              displayNameEn: 'Designer',
+              family: { displayNameEn: 'Design' },
+            },
+            skills: [],
+          },
+        },
+        {
+          id: 'apply-2',
+          jdId: 'jd-2',
+          status: 'accepted',
+          createdAt: new Date('2026-02-02T00:00:00.000Z'),
+          jd: {
+            id: 'jd-2',
+            title: 'Backend Developer',
+            employmentType: 'full_time',
+            workArrangement: 'remote',
+            org: { name: 'PayNest' },
+            job: {
+              displayNameEn: 'Backend',
+              family: { displayNameEn: 'Develop' },
+            },
+            skills: [],
+          },
+        },
+      ],
+    });
+
+    const ui = await MyApplicationsPage();
+    render(ui);
+
+    expect(screen.getByText('My Jobs')).toBeInTheDocument();
+    expect(screen.getByText('Applied')).toBeInTheDocument();
+    expect(screen.getByText('In progress')).toBeInTheDocument();
+    expect(screen.getByText('Product Designer')).toBeInTheDocument();
+    expect(screen.getByText('Backend Developer')).toBeInTheDocument();
+  });
+});

--- a/__tests__/app/candidate-slug-page.test.tsx
+++ b/__tests__/app/candidate-slug-page.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import CandidateSlugPage from '@/app/candidate/[slug]/page';
+import { getProfileBySlug } from '@/lib/actions/profile';
+import { getCurrentUser } from '@/lib/infrastructure/auth-utils';
+import { getMyApplications } from '@/lib/actions/applications';
+
+jest.mock('@/lib/actions/profile', () => ({
+  getProfileBySlug: jest.fn(),
+}));
+jest.mock('@/lib/infrastructure/auth-utils', () => ({
+  getCurrentUser: jest.fn(),
+  requireUser: jest.fn(),
+  requireRole: jest.fn(),
+}));
+jest.mock('@/lib/actions/applications', () => ({
+  getMyApplications: jest.fn(),
+}));
+
+const mockGetProfileBySlug = getProfileBySlug as unknown as jest.Mock;
+const mockGetCurrentUser = getCurrentUser as unknown as jest.Mock;
+const mockGetMyApplications = getMyApplications as unknown as jest.Mock;
+
+const profileData = {
+  id: 'user-1',
+  authUser: { email: 'lion@vridge.net' },
+  profilePublic: {
+    firstName: 'Lion',
+    lastName: 'Park',
+    dateOfBirth: new Date('2000-02-10T00:00:00.000Z'),
+    location: 'Ho Chi Minh City',
+    headline: 'Product Designer',
+    aboutMe: '소개',
+    isOpenToWork: true,
+    profileImageUrl: null,
+    isPublic: true,
+    publicSlug: 'lion-park',
+  },
+  profilePrivate: null,
+  careers: [],
+  educations: [],
+  languages: [],
+  urls: [],
+  profileSkills: [],
+  certifications: [],
+};
+
+describe('CandidateSlugPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetProfileBySlug.mockResolvedValue({
+      success: true,
+      data: profileData,
+    });
+  });
+
+  it('소유자일 때 My Jobs 통계를 보여준다', async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      userId: 'user-1',
+      email: 'lion@vridge.net',
+      role: 'candidate',
+      orgId: null,
+    });
+    mockGetMyApplications.mockResolvedValue({
+      success: true,
+      data: [
+        { status: 'applied' },
+        { status: 'accepted' },
+        { status: 'applied' },
+      ],
+    });
+
+    const ui = await CandidateSlugPage({
+      params: Promise.resolve({ slug: 'lion-park' }),
+    });
+    render(ui);
+
+    expect(screen.getByText('My Jobs')).toBeInTheDocument();
+    expect(screen.getByText('Applied')).toBeInTheDocument();
+    expect(screen.getByText('In progress')).toBeInTheDocument();
+  });
+
+  it('비소유자일 때 My Jobs 통계를 숨긴다', async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+
+    const ui = await CandidateSlugPage({
+      params: Promise.resolve({ slug: 'lion-park' }),
+    });
+    render(ui);
+
+    expect(screen.queryByText('My Jobs')).not.toBeInTheDocument();
+    expect(mockGetMyApplications).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/actions/profile.test.ts
+++ b/__tests__/lib/actions/profile.test.ts
@@ -7,6 +7,7 @@ import {
   addProfileSkill,
   deleteProfileSkill,
   getMyProfile,
+  getProfileBySlug,
   getProfileForRecruiter,
   addProfileCertification,
   updateProfileCertification,
@@ -305,6 +306,37 @@ describe('getMyProfile', () => {
     );
 
     await expect(getMyProfile()).rejects.toThrow('Unauthorized');
+  });
+});
+
+describe('getProfileBySlug', () => {
+  it('공개 프로필 조회 성공', async () => {
+    const profileData = {
+      id: 'candidate-1',
+      profilePublic: { firstName: '이', lastName: '영희', isPublic: true },
+    };
+    (
+      profileUseCases.getProfileBySlug as unknown as jest.Mock
+    ).mockResolvedValue(profileData);
+
+    const result = await getProfileBySlug('candidate-1-slug');
+
+    expect(result).toEqual({ success: true, data: profileData });
+    expect(profileUseCases.getProfileBySlug).toHaveBeenCalledWith(
+      'candidate-1-slug'
+    );
+  });
+
+  it('존재하지 않는 slug → { error: ... }', async () => {
+    (
+      profileUseCases.getProfileBySlug as unknown as jest.Mock
+    ).mockRejectedValue(
+      new DomainError('NOT_FOUND', '프로필을(를) 찾을 수 없습니다')
+    );
+
+    const result = await getProfileBySlug('missing-slug');
+
+    expect(result).toEqual({ error: '프로필을(를) 찾을 수 없습니다' });
   });
 });
 

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -31,8 +31,18 @@ describe('공개 라우트', () => {
     expect(mockGetSession).not.toHaveBeenCalled();
   });
 
-  it('/announcement/* 은 세션 확인 없이 통과', async () => {
-    await proxy(makeRequest('/announcement/1'));
+  it('/announcements/* 은 세션 확인 없이 통과', async () => {
+    await proxy(makeRequest('/announcements/1'));
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it('/candidate/[slug] 공개 라우트는 세션 확인 없이 통과', async () => {
+    await proxy(makeRequest('/candidate/lion-park'));
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it('/candidate/[slug]/profile 공개 라우트는 세션 확인 없이 통과', async () => {
+    await proxy(makeRequest('/candidate/lion-park/profile'));
     expect(mockGetSession).not.toHaveBeenCalled();
   });
 

--- a/__tests__/widgets/nav/main-nav.test.tsx
+++ b/__tests__/widgets/nav/main-nav.test.tsx
@@ -72,9 +72,9 @@ describe('MainNav', () => {
     expect(jobsLink.className).toContain('text-brand');
   });
 
-  it('/announcement 경로 — Announcement 링크에 활성 클래스 적용', () => {
+  it('/announcements 경로 — Announcement 링크에 활성 클래스 적용', () => {
     mockUseSession.mockReturnValue({ data: null });
-    mockUsePathname.mockReturnValue('/announcement');
+    mockUsePathname.mockReturnValue('/announcements');
     render(<MainNav />);
 
     const announcementLink = screen.getByRole('link', { name: 'Announcement' });

--- a/app/(dashboard)/candidate/profile/page.tsx
+++ b/app/(dashboard)/candidate/profile/page.tsx
@@ -1,115 +1,21 @@
-import Link from 'next/link';
-import { requireUser } from '@/lib/infrastructure/auth-utils';
+import { redirect } from 'next/navigation';
 import { getMyProfile } from '@/lib/actions/profile';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { SectionTitle } from '@/components/ui/section-title';
-import { SkillBadges } from '@/entities/profile/ui/skill-badges';
-import { CareerList } from '@/entities/profile/ui/career-list';
-import { EducationList } from '@/entities/profile/ui/education-list';
-import { LanguageList } from '@/entities/profile/ui/language-list';
-import { UrlList } from '@/entities/profile/ui/url-list';
-import { ProfileCard } from '@/entities/profile/ui/profile-card';
-import { CertificationList } from '@/entities/profile/ui/certification-list';
+import { requireUser } from '@/lib/infrastructure/auth-utils';
 
 export default async function CandidateProfilePage() {
-  const user = await requireUser();
+  await requireUser();
   const result = await getMyProfile();
 
   if ('error' in result) {
     return <p className="text-destructive">{result.error}</p>;
   }
 
-  const {
-    profilePublic,
-    profilePrivate,
-    careers,
-    educations,
-    languages,
-    urls,
-    profileSkills,
-    certifications,
-  } = result.data;
+  const slug = result.data.profilePublic?.publicSlug;
+  if (!slug) {
+    return (
+      <p className="text-destructive">프로필 공개 URL을 찾을 수 없습니다.</p>
+    );
+  }
 
-  return (
-    <div className="flex flex-col gap-6 p-6">
-      <div className="flex items-start justify-between">
-        <SectionTitle title="기본 정보" />
-        <Button variant="outline" size="sm" asChild>
-          <Link href="/candidate/profile/edit">편집</Link>
-        </Button>
-      </div>
-
-      <Card>
-        <CardContent>
-          <ProfileCard
-            firstName={profilePublic?.firstName ?? ''}
-            lastName={profilePublic?.lastName ?? ''}
-            dateOfBirth={profilePublic?.dateOfBirth ?? undefined}
-            phone={profilePrivate?.phoneNumber}
-            email={user.email}
-            location={profilePublic?.location}
-            headline={profilePublic?.headline}
-            aboutMe={profilePublic?.aboutMe}
-            isOpenToWork={profilePublic?.isOpenToWork ?? false}
-            profileImageUrl={profilePublic?.profileImageUrl}
-          />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="학력" />
-        </CardHeader>
-        <CardContent>
-          <EducationList educations={educations} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="스킬" />
-        </CardHeader>
-        <CardContent>
-          <SkillBadges skills={profileSkills} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="경력" />
-        </CardHeader>
-        <CardContent>
-          <CareerList careers={careers} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="자격증" />
-        </CardHeader>
-        <CardContent>
-          <CertificationList certifications={certifications} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="언어" />
-        </CardHeader>
-        <CardContent>
-          <LanguageList languages={languages} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="링크" />
-        </CardHeader>
-        <CardContent>
-          <UrlList urls={urls} />
-        </CardContent>
-      </Card>
-    </div>
-  );
+  redirect(`/candidate/${slug}/profile`);
 }

--- a/app/announcements/[id]/page.tsx
+++ b/app/announcements/[id]/page.tsx
@@ -1,0 +1,100 @@
+import Link from 'next/link';
+import ReactMarkdown from 'react-markdown';
+import { Icon } from '@/components/ui/icon';
+import {
+  getAnnouncementById,
+  getAnnouncementNeighbors,
+} from '@/lib/actions/announcements';
+
+function formatDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}.${month}.${day}`;
+}
+
+export default async function AnnouncementDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const [detailResult, neighborsResult] = await Promise.all([
+    getAnnouncementById(id),
+    getAnnouncementNeighbors(id),
+  ]);
+
+  if ('error' in detailResult) {
+    return <p className="p-6 text-destructive">{detailResult.error}</p>;
+  }
+
+  if ('error' in neighborsResult) {
+    return <p className="p-6 text-destructive">{neighborsResult.error}</p>;
+  }
+
+  const announcement = detailResult.data;
+  const neighbors = neighborsResult.data;
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-7 px-6 py-10">
+      <Link
+        href="/announcements"
+        aria-label="announcement 목록"
+        className="inline-flex w-fit items-center text-black hover:text-brand"
+      >
+        <Icon name="arrow-left" size={24} />
+      </Link>
+
+      <div className="flex flex-col gap-2">
+        <h1 className="text-3xl font-bold">{announcement.title}</h1>
+        <div className="inline-flex items-center gap-2 text-sm font-medium text-[#666]">
+          {announcement.isPinned && <span>(Pinned)</span>}
+          <span>{formatDate(announcement.createdAt)}</span>
+        </div>
+      </div>
+
+      <div className="bg-neutral-50 rounded-[20px] px-5 py-6">
+        <div className="prose prose-sm max-w-none">
+          <ReactMarkdown>{announcement.content}</ReactMarkdown>
+        </div>
+      </div>
+
+      <div className="flex flex-col border-y border-black">
+        <div className="grid grid-cols-[96px_1fr_192px] items-center gap-4 border-b border-black py-5 text-sm font-medium text-[#666]">
+          <span className="text-center">Next</span>
+          {neighbors.next ? (
+            <Link
+              href={`/announcements/${neighbors.next.id}`}
+              className="hover:text-brand"
+            >
+              {neighbors.next.title}
+            </Link>
+          ) : (
+            <span className="text-[#999]">다음 공지 없음</span>
+          )}
+          <span className="text-center">
+            {neighbors.next ? formatDate(neighbors.next.createdAt) : '-'}
+          </span>
+        </div>
+
+        <div className="grid grid-cols-[96px_1fr_192px] items-center gap-4 py-5 text-sm font-medium text-[#666]">
+          <span className="text-center">Before</span>
+          {neighbors.before ? (
+            <Link
+              href={`/announcements/${neighbors.before.id}`}
+              className="hover:text-brand"
+            >
+              {neighbors.before.title}
+            </Link>
+          ) : (
+            <span className="text-[#999]">이전 공지 없음</span>
+          )}
+          <span className="text-center">
+            {neighbors.before ? formatDate(neighbors.before.createdAt) : '-'}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -1,0 +1,80 @@
+import Link from 'next/link';
+import { NumberedPagination } from '@/components/ui/numbered-pagination';
+import { SectionTitle } from '@/components/ui/section-title';
+import { getAnnouncements } from '@/lib/actions/announcements';
+
+function parsePage(input: string | string[] | undefined): number {
+  if (Array.isArray(input)) return parsePage(input[0]);
+  const parsed = Number(input);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function formatDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}.${month}.${day}`;
+}
+
+export default async function AnnouncementsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const page = parsePage(params.page);
+  const result = await getAnnouncements({ page });
+
+  if ('error' in result) {
+    return <p className="p-6 text-destructive">{result.error}</p>;
+  }
+
+  const { items, total, pageSize } = result.data;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const offset = (page - 1) * pageSize;
+
+  function buildHref(nextPage: number) {
+    return nextPage <= 1 ? '/announcements' : `/announcements?page=${nextPage}`;
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-6 px-6 py-10">
+      <SectionTitle title="Announcement" />
+
+      <div className="flex flex-col border-t-2 border-black">
+        <div className="grid grid-cols-[96px_1fr_192px] border-b border-black py-4 text-center text-xl font-medium">
+          <span>No</span>
+          <span>Title</span>
+          <span>Time</span>
+        </div>
+
+        {items.map((item, index) => {
+          const rowNumber = total - (offset + index);
+          return (
+            <div
+              key={item.id}
+              className="grid grid-cols-[96px_1fr_192px] items-center gap-4 border-b border-black py-5 text-lg font-medium text-[#333]"
+            >
+              <span className="text-center">
+                {item.isPinned ? '📍' : rowNumber}
+              </span>
+              <Link
+                href={`/announcements/${item.id}`}
+                className="hover:text-brand"
+              >
+                {item.title}
+              </Link>
+              <span className="text-center">{formatDate(item.createdAt)}</span>
+            </div>
+          );
+        })}
+      </div>
+
+      <NumberedPagination
+        currentPage={page}
+        totalPages={totalPages}
+        buildHref={buildHref}
+      />
+    </div>
+  );
+}

--- a/app/candidate/[slug]/page.tsx
+++ b/app/candidate/[slug]/page.tsx
@@ -1,0 +1,87 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { SectionTitle } from '@/components/ui/section-title';
+import { ProfileCard } from '@/entities/profile/ui/profile-card';
+import { getMyApplications } from '@/lib/actions/applications';
+import { getProfileBySlug } from '@/lib/actions/profile';
+import { getCurrentUser } from '@/lib/infrastructure/auth-utils';
+
+export default async function CandidateLandingPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const [profileResult, currentUser] = await Promise.all([
+    getProfileBySlug(slug),
+    getCurrentUser(),
+  ]);
+
+  if ('error' in profileResult) {
+    return <p className="p-6 text-destructive">{profileResult.error}</p>;
+  }
+
+  const { id, authUser, profilePublic } = profileResult.data;
+  const isOwner = currentUser?.userId === id;
+
+  let appliedCount = 0;
+  let inProgressCount = 0;
+
+  if (isOwner) {
+    const applicationsResult = await getMyApplications();
+    if ('success' in applicationsResult) {
+      appliedCount = applicationsResult.data.filter(
+        (item) => item.status === 'applied'
+      ).length;
+      inProgressCount = applicationsResult.data.filter(
+        (item) => item.status === 'accepted'
+      ).length;
+    }
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-6 px-6 py-8">
+      <Card>
+        <CardHeader>
+          <SectionTitle title="My Profile" />
+        </CardHeader>
+        <CardContent>
+          <ProfileCard
+            firstName={profilePublic?.firstName ?? ''}
+            lastName={profilePublic?.lastName ?? ''}
+            dateOfBirth={profilePublic?.dateOfBirth ?? undefined}
+            email={authUser?.email}
+            location={profilePublic?.location}
+            headline={profilePublic?.headline}
+            aboutMe={profilePublic?.aboutMe}
+            isOpenToWork={profilePublic?.isOpenToWork ?? false}
+            profileImageUrl={profilePublic?.profileImageUrl}
+          />
+        </CardContent>
+      </Card>
+
+      {isOwner && (
+        <Card>
+          <CardHeader>
+            <SectionTitle title="My Jobs" />
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <div className="bg-neutral-50 rounded-[20px] px-10 py-8 text-center">
+                <p className="text-xl font-bold text-[#1a1a1a]">Applied</p>
+                <p className="text-xl font-bold text-[#1a1a1a]">
+                  {appliedCount}
+                </p>
+              </div>
+              <div className="bg-neutral-50 rounded-[20px] px-10 py-8 text-center">
+                <p className="text-xl font-bold text-[#4c4c4c]">In progress</p>
+                <p className="text-xl font-bold text-[#4c4c4c]">
+                  {inProgressCount}
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/app/candidate/[slug]/profile/page.tsx
+++ b/app/candidate/[slug]/profile/page.tsx
@@ -1,0 +1,111 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { SectionTitle } from '@/components/ui/section-title';
+import { ProfileCard } from '@/entities/profile/ui/profile-card';
+import { EducationList } from '@/entities/profile/ui/education-list';
+import { SkillBadges } from '@/entities/profile/ui/skill-badges';
+import { CareerList } from '@/entities/profile/ui/career-list';
+import { CertificationList } from '@/entities/profile/ui/certification-list';
+import { LanguageList } from '@/entities/profile/ui/language-list';
+import { UrlList } from '@/entities/profile/ui/url-list';
+import { getProfileBySlug } from '@/lib/actions/profile';
+
+export default async function CandidatePublicProfilePage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const result = await getProfileBySlug(slug);
+
+  if ('error' in result) {
+    return <p className="p-6 text-destructive">{result.error}</p>;
+  }
+
+  const {
+    authUser,
+    profilePublic,
+    careers,
+    educations,
+    languages,
+    urls,
+    profileSkills,
+    certifications,
+  } = result.data;
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-6 px-6 py-8">
+      <Card>
+        <CardHeader>
+          <SectionTitle title="Basic Profile" />
+        </CardHeader>
+        <CardContent>
+          <ProfileCard
+            firstName={profilePublic?.firstName ?? ''}
+            lastName={profilePublic?.lastName ?? ''}
+            dateOfBirth={profilePublic?.dateOfBirth ?? undefined}
+            email={authUser?.email}
+            location={profilePublic?.location}
+            headline={profilePublic?.headline}
+            aboutMe={profilePublic?.aboutMe}
+            isOpenToWork={profilePublic?.isOpenToWork ?? false}
+            profileImageUrl={profilePublic?.profileImageUrl}
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <SectionTitle title="Education" />
+        </CardHeader>
+        <CardContent>
+          <EducationList educations={educations} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <SectionTitle title="Skills" />
+        </CardHeader>
+        <CardContent>
+          <SkillBadges skills={profileSkills} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <SectionTitle title="Experience" />
+        </CardHeader>
+        <CardContent>
+          <CareerList careers={careers} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <SectionTitle title="Certification" />
+        </CardHeader>
+        <CardContent>
+          <CertificationList certifications={certifications} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <SectionTitle title="Languages" />
+        </CardHeader>
+        <CardContent>
+          <LanguageList languages={languages} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <SectionTitle title="Portfolio" />
+        </CardHeader>
+        <CardContent>
+          <UrlList urls={urls} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/docs/implementation-plan-p5.md
+++ b/docs/implementation-plan-p5.md
@@ -307,6 +307,17 @@ P24 (Polish + E2E) depends on all
 
 **Tests**: Announcement query coverage (from P18), slug use-case tests, proxy path tests, main-nav link update.
 
+#### Prompt 23 results
+
+- 공지사항 목록/상세 페이지를 추가했다: `/announcements`, `/announcements/[id]` (핀 고정글, 날짜 표시, 다음/이전 글 내비게이션 포함).
+- 공지사항 상세 인접 글 조회를 위해 `getAnnouncementNeighbors` use-case/action을 추가했다.
+- 네비게이션 및 공개 경로를 단수 `/announcement`에서 복수 `/announcements`로 정리했다 (`MainNav`, `proxy` 반영).
+- 공개 프로필 슬러그 조회 흐름을 추가했다: `getProfileBySlug` use-case/action + `/candidate/[slug]`, `/candidate/[slug]/profile`.
+- 대시보드 `/candidate/profile`은 내 slug 기반 공개 프로필로 리다이렉트하도록 변경했다.
+- `/candidate/applications`를 Prompt 20 재사용 원칙에 맞춰 개편했다 (`PostingListItem` 기반 목록 + 요약 카드).
+- 테스트를 확장했다: 공지사항 페이지/상세, 후보자 slug 페이지, 지원 목록 페이지, nav/proxy/profile/announcement use-case·action.
+- 전체 검증 완료: `63 suite`, `424 tests`, `tsc --noEmit` 클린.
+
 ---
 
 ## Prompt 24: Polish + E2E
@@ -365,5 +376,5 @@ P24 (Polish + E2E) depends on all
 | 20  | Design system components (Icon, InputWithIcon, StatusIndicator, Pagination, Button brand) | Small        | —             | ✅     |
 | 21  | Jobs route merge + list/detail UI redesign                                                | Large        | P20           | ✅     |
 | 22  | Profile view/edit with all new fields + certification section                             | Large        | P18, P20      | ✅     |
-| 23  | Announcements pages + candidate landing + shareable slugs                                 | Large        | P18, P20, P22 | ⬜     |
+| 23  | Announcements pages + candidate landing + shareable slugs                                 | Large        | P18, P20, P22 | ✅     |
 | 24  | Error handling + loading states + E2E smoke test                                          | Medium       | All           | ⬜     |

--- a/lib/actions/announcements.ts
+++ b/lib/actions/announcements.ts
@@ -6,6 +6,7 @@ import { announcementFilterSchema } from '@/lib/validations/announcement';
 import {
   getAnnouncements as ucGetAnnouncements,
   getAnnouncementById as ucGetAnnouncementById,
+  getAnnouncementNeighbors as ucGetAnnouncementNeighbors,
 } from '@/lib/use-cases/announcements';
 
 type QueryResult<T> = { success: true; data: T } | { error: string };
@@ -33,6 +34,19 @@ export async function getAnnouncementById(
 ): Promise<QueryResult<Awaited<ReturnType<typeof ucGetAnnouncementById>>>> {
   try {
     const data = await ucGetAnnouncementById(id);
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function getAnnouncementNeighbors(
+  id: string
+): Promise<
+  QueryResult<Awaited<ReturnType<typeof ucGetAnnouncementNeighbors>>>
+> {
+  try {
+    const data = await ucGetAnnouncementNeighbors(id);
     return { success: true, data };
   } catch (e) {
     return handleError(e);

--- a/lib/actions/profile.ts
+++ b/lib/actions/profile.ts
@@ -21,6 +21,7 @@ import {
 } from '@/lib/validations/profile';
 import {
   getFullProfile,
+  getProfileBySlug as ucGetProfileBySlug,
   getProfileForViewer,
   updatePublicProfile,
   updatePrivateProfile,
@@ -335,6 +336,17 @@ export async function getProfileForRecruiter(
         .then((r) => r !== null);
     await assertCanViewCandidate(user.role as AppRole, candidateId, checker);
     const data = await getProfileForViewer(candidateId, 'full');
+    return { success: true, data };
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+export async function getProfileBySlug(
+  slug: string
+): Promise<QueryResult<Awaited<ReturnType<typeof ucGetProfileBySlug>>>> {
+  try {
+    const data = await ucGetProfileBySlug(slug);
     return { success: true, data };
   } catch (e) {
     return handleError(e);

--- a/lib/use-cases/announcements.ts
+++ b/lib/use-cases/announcements.ts
@@ -25,3 +25,21 @@ export async function getAnnouncementById(id: string) {
   if (!announcement) throw notFound('공지사항');
   return announcement;
 }
+
+export async function getAnnouncementNeighbors(id: string) {
+  const current = await prisma.announcement.findUnique({ where: { id } });
+  if (!current) throw notFound('공지사항');
+
+  const ordered = await prisma.announcement.findMany({
+    select: { id: true, title: true, isPinned: true, createdAt: true },
+    orderBy: [{ isPinned: 'desc' }, { createdAt: 'desc' }, { id: 'desc' }],
+  });
+
+  const currentIndex = ordered.findIndex((item) => item.id === id);
+  if (currentIndex === -1) throw notFound('공지사항');
+
+  return {
+    next: ordered[currentIndex + 1] ?? null,
+    before: ordered[currentIndex - 1] ?? null,
+  };
+}

--- a/lib/use-cases/applications.ts
+++ b/lib/use-cases/applications.ts
@@ -47,6 +47,7 @@ export async function getUserApplications(userId: string) {
         include: {
           job: { include: { family: true } },
           org: true,
+          skills: { include: { skill: true } },
         },
       },
     },

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,10 +2,22 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/infrastructure/auth';
 
 function isPublicPath(pathname: string): boolean {
+  const segments = pathname.split('/').filter(Boolean);
+  const isPublicCandidatePath =
+    segments[0] === 'candidate' &&
+    ((segments.length === 2 &&
+      segments[1] !== 'profile' &&
+      segments[1] !== 'applications') ||
+      (segments.length === 3 &&
+        segments[2] === 'profile' &&
+        segments[1] !== 'profile' &&
+        segments[1] !== 'applications'));
+
   return (
     pathname === '/' ||
     pathname.startsWith('/jobs') ||
-    pathname.startsWith('/announcement') ||
+    pathname.startsWith('/announcements') ||
+    isPublicCandidatePath ||
     pathname.startsWith('/api/auth')
   );
 }

--- a/todo.md
+++ b/todo.md
@@ -59,7 +59,7 @@
 | 20  | 디자인 시스템 컴포넌트            | Icon, InputWithIcon, StatusIndicator, Pagination | —             | ✅   |
 | 21  | 채용공고 라우트 통합 + UI 재설계  | `/candidate/jobs` → `/jobs` 통합, 검색/탭/정렬   | P20           | ✅   |
 | 22  | 프로필 조회/편집 재설계           | 새 필드 반영, 자격증 섹션, 섹션 순서 변경        | P18, P20      | ✅   |
-| 23  | 공지사항 + 후보자 랜딩 + 공유 URL | 공지 목록/상세, 프로필 슬러그                    | P18, P20, P22 | ⬜   |
+| 23  | 공지사항 + 후보자 랜딩 + 공유 URL | 공지 목록/상세, 프로필 슬러그                    | P18, P20, P22 | ✅   |
 | 24  | 에러 처리 + 로딩 + E2E 테스트     | error.tsx, loading.tsx, 스모크 테스트            | 전체          | ⬜   |
 
 ---
@@ -79,6 +79,6 @@
 
 ## 현재 상태
 
-- **테스트**: 408개 통과 (59 suite)
+- **테스트**: 424개 통과 (63 suite)
 - **타입 체크**: `tsc --noEmit` 클린
-- **브랜치**: `feat/prompt21-sort-query-state`
+- **브랜치**: `feat/prompt23-announcement-slug`

--- a/widgets/nav/ui/main-nav.tsx
+++ b/widgets/nav/ui/main-nav.tsx
@@ -9,7 +9,7 @@ import UserMenu from './user-menu';
 
 const NAV_LINKS = [
   { label: 'Jobs', href: '/jobs' },
-  { label: 'Announcement', href: '/announcement' },
+  { label: 'Announcement', href: '/announcements' },
 ];
 
 export default function MainNav() {


### PR DESCRIPTION
## 구현 내용
- `/announcements`, `/announcements/[id]` 페이지 구현 (목록/상세, 핀 고정글 표시, 다음/이전 글 내비게이션).
- 공지 상세 인접 글 조회 로직 추가: `getAnnouncementNeighbors` (use-case/action).
- 후보자 공개 라우트 추가: `/candidate/[slug]`, `/candidate/[slug]/profile`.
- 대시보드 `/candidate/profile`을 내 slug 프로필로 리다이렉트하도록 변경.
- `/candidate/applications` UI를 Prompt 20 컴포넌트 재사용 원칙으로 개편(`PostingListItem` + 요약 카드).
- 네비게이션/프록시 경로를 `/announcement` -> `/announcements`로 정리.
- 문서 업데이트: `docs/implementation-plan-p5.md`, `todo.md` (Prompt 23 결과/상태 반영).

## 주요 변경 파일
- `app/announcements/page.tsx`
- `app/announcements/[id]/page.tsx`
- `app/candidate/[slug]/page.tsx`
- `app/candidate/[slug]/profile/page.tsx`
- `app/(dashboard)/candidate/profile/page.tsx`
- `app/(dashboard)/candidate/applications/page.tsx`
- `lib/use-cases/announcements.ts`
- `lib/actions/announcements.ts`
- `lib/use-cases/profile.ts`
- `lib/actions/profile.ts`
- `proxy.ts`
- `widgets/nav/ui/main-nav.tsx`
- `__tests__/app/*`, `__tests__/lib/*`, `__tests__/proxy.test.ts`, `__tests__/widgets/nav/main-nav.test.tsx`
- `docs/implementation-plan-p5.md`, `todo.md`

## 테스트
- `pnpm test`: 63 suite, 424 tests 통과
- `pnpm tsc --noEmit`: 통과