### PR TITLE
feat: Prompt 23 UI 정렬 및 프로필 편집 저장 흐름 개선

### DIFF
--- a/__tests__/features/auth/login-modal.test.tsx
+++ b/__tests__/features/auth/login-modal.test.tsx
@@ -62,7 +62,7 @@ describe('LoginModal', () => {
     fireEvent.change(screen.getByLabelText(/password/i), {
       target: { value: 'password123' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /log in/i }));
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
 
     await waitFor(() => {
       expect(signIn.email).toHaveBeenCalledWith(

--- a/app/(dashboard)/candidate/profile/edit/page.tsx
+++ b/app/(dashboard)/candidate/profile/edit/page.tsx
@@ -1,20 +1,10 @@
-import Link from 'next/link';
 import { requireUser } from '@/lib/infrastructure/auth-utils';
 import { getMyProfile } from '@/lib/actions/profile';
 import { getJobFamilies } from '@/lib/actions/catalog';
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
-import { SectionTitle } from '@/components/ui/section-title';
-import { ProfilePublicForm } from '@/features/profile-edit/ui/profile-public-form';
-import { ContactForm } from '@/features/profile-edit/ui/contact-form';
-import { CareerSection } from '@/features/profile-edit/ui/career-form';
-import { EducationSection } from '@/features/profile-edit/ui/education-form';
-import { LanguageSection } from '@/features/profile-edit/ui/language-form';
-import { UrlSection } from '@/features/profile-edit/ui/url-form';
-import { SkillPicker } from '@/features/profile-edit/ui/skill-picker';
-import { CertificationSection } from '@/features/profile-edit/ui/certification-form';
+import { ProfileEditPageClient } from '@/features/profile-edit/ui/profile-edit-page-client';
 
 export default async function CandidateProfileEditPage() {
-  await requireUser();
+  const user = await requireUser();
   const [profileResult, familiesResult] = await Promise.all([
     getMyProfile(),
     getJobFamilies(),
@@ -79,85 +69,34 @@ export default async function CandidateProfileEditPage() {
   }));
 
   return (
-    <div className="flex flex-col gap-6 p-6">
-      <Link
-        href="/candidate/profile"
-        className="text-sm text-muted-foreground hover:underline"
-      >
-        ← 프로필로 돌아가기
-      </Link>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="기본 정보" />
-        </CardHeader>
-        <CardContent>
-          <ProfilePublicForm initialData={profilePublic ?? undefined} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="연락처" />
-        </CardHeader>
-        <CardContent>
-          <ContactForm initialData={profilePrivate ?? undefined} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="스킬" />
-        </CardHeader>
-        <CardContent>
-          <SkillPicker currentSkills={profileSkills} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="경력" />
-        </CardHeader>
-        <CardContent>
-          <CareerSection careers={careers} jobFamilies={jobFamilies} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="학력" />
-        </CardHeader>
-        <CardContent>
-          <EducationSection educations={educations} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="자격증" />
-        </CardHeader>
-        <CardContent>
-          <CertificationSection certifications={certifications} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="언어" />
-        </CardHeader>
-        <CardContent>
-          <LanguageSection languages={languages} />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <SectionTitle title="링크" />
-        </CardHeader>
-        <CardContent>
-          <UrlSection urls={urls} />
-        </CardContent>
-      </Card>
-    </div>
+    <ProfileEditPageClient
+      profilePublic={
+        profilePublic
+          ? {
+              firstName: profilePublic.firstName,
+              lastName: profilePublic.lastName,
+              aboutMe: profilePublic.aboutMe,
+              dateOfBirth: profilePublic.dateOfBirth
+                ? profilePublic.dateOfBirth.toISOString().split('T')[0]
+                : undefined,
+              location: profilePublic.location,
+              headline: profilePublic.headline,
+              isOpenToWork: profilePublic.isOpenToWork,
+            }
+          : undefined
+      }
+      profilePrivate={profilePrivate ?? undefined}
+      email={user.email}
+      jobFamilies={jobFamilies}
+      skills={profileSkills.map(({ skill }) => ({
+        id: skill.id,
+        displayNameEn: skill.displayNameEn,
+      }))}
+      careers={careers}
+      educations={educations}
+      certifications={certifications}
+      languages={languages}
+      urls={urls}
+    />
   );
 }

--- a/docs/implementation-plan-p5.md
+++ b/docs/implementation-plan-p5.md
@@ -315,6 +315,10 @@ P24 (Polish + E2E) depends on all
 - 공개 프로필 슬러그 조회 흐름을 추가했다: `getProfileBySlug` use-case/action + `/candidate/[slug]`, `/candidate/[slug]/profile`.
 - 대시보드 `/candidate/profile`은 내 slug 기반 공개 프로필로 리다이렉트하도록 변경했다.
 - `/candidate/applications`를 Prompt 20 재사용 원칙에 맞춰 개편했다 (`PostingListItem` 기반 목록 + 요약 카드).
+- 프로필 편집 페이지를 서버/클라이언트 오케스트레이션 구조로 재구성했다: `ProfileEditPageClient` 기반 전역 draft/baseline 비교, 하단 고정 Save 바, 섹션별 diff 저장 파이프라인 적용.
+- 미저장 이탈 방지 가드를 추가했다 (`beforeunload`, 링크 클릭, 뒤로가기 confirm).
+- 로그인/회원가입 모달을 Figma 구조에 맞게 재정렬하면서 기존 인증 동작을 유지했다 (소셜 로그인, 이메일/비밀번호, 3-step signup).
+- Prompt 20 공유 컴포넌트 재사용을 강화했다 (`FormInput`, `Icon`, `Button`, `ToggleSwitch`, `SectionTitle`, `DatePicker`, `FormDropdown`, `SearchBar`, `Chip`, `DialcodePicker`).
 - 테스트를 확장했다: 공지사항 페이지/상세, 후보자 slug 페이지, 지원 목록 페이지, nav/proxy/profile/announcement use-case·action.
 - 전체 검증 완료: `63 suite`, `424 tests`, `tsc --noEmit` 클린.
 

--- a/features/auth/ui/login-modal.tsx
+++ b/features/auth/ui/login-modal.tsx
@@ -2,18 +2,18 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import Image from 'next/image';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
+  DialogDescription,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
+import { FormInput } from '@/components/ui/form-input';
+import { Icon } from '@/components/ui/icon';
 import { signIn } from '@/lib/infrastructure/auth-client';
 import { useAuthModal } from '../model/use-auth-modal';
 import { PasswordInput } from './password-input';
@@ -54,137 +54,201 @@ export function LoginModal() {
 
   return (
     <Dialog open={isLoginOpen} onOpenChange={(open) => !open && closeAll()}>
-      <DialogContent className="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle>로그인</DialogTitle>
-          <p className="text-sm text-muted-foreground">
-            계정이 없으신가요?{' '}
+      <DialogContent
+        showCloseButton={false}
+        className="w-[712px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-[20px] border-0 bg-white p-0 shadow-[0_0_15px_7px_rgba(255,149,84,0.07)]"
+      >
+        <div className="flex flex-col items-center gap-10 px-5 pt-5 pb-20">
+          <div className="flex w-full items-center justify-between">
+            <p className="text-sm text-[#666]">
+              Don&apos;t have an account yet?{' '}
+              <button
+                type="button"
+                onClick={openSignup}
+                className="underline underline-offset-2"
+              >
+                Sign up
+              </button>
+            </p>
             <button
               type="button"
-              onClick={openSignup}
-              className="font-medium text-brand hover:underline"
+              onClick={closeAll}
+              aria-label="Close login modal"
+              className="rounded-sm p-1 text-[#1a1a1a] hover:bg-[#f5f5f5]"
             >
-              Sign Up
+              <Icon name="close" size={16} />
             </button>
-          </p>
-        </DialogHeader>
+          </div>
 
-        <div className="flex flex-col gap-3">
-          <Button
-            variant="outline"
-            type="button"
-            className="w-full gap-2"
-            onClick={() =>
-              signIn.social({
-                provider: 'google',
-                callbackURL: '/candidate/profile',
-              })
-            }
-          >
-            <Image src="/icons/google.svg" alt="" width={20} height={20} />
-            Sign up with Google
-          </Button>
-          <Button
-            variant="outline"
-            type="button"
-            className="w-full gap-2"
-            onClick={() =>
-              signIn.social({
-                provider: 'facebook',
-                callbackURL: '/candidate/profile',
-              })
-            }
-          >
-            <Image src="/icons/facebook.svg" alt="" width={20} height={20} />
-            Sign up with Facebook
-          </Button>
-        </div>
+          <div className="flex w-full max-w-[520px] flex-col items-center gap-10">
+            <DialogTitle className="text-2xl font-bold text-[#1f1f1f]">
+              Login
+            </DialogTitle>
+            <DialogDescription className="sr-only">
+              Log in to access your account.
+            </DialogDescription>
 
-        <div className="relative flex items-center py-2">
-          <div className="grow border-t" />
-          <span className="px-3 text-xs text-muted-foreground">or</span>
-          <div className="grow border-t" />
-        </div>
-
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            form.handleSubmit();
-          }}
-          className="flex flex-col gap-4"
-        >
-          <form.Field name="email">
-            {(field) => (
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="login-email">Email</Label>
-                <Input
-                  id="login-email"
-                  type="email"
-                  autoComplete="email"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  onBlur={field.handleBlur}
-                />
-                {field.state.meta.isTouched &&
-                  field.state.meta.errors.length > 0 && (
-                    <p className="text-xs text-destructive">
-                      {String(
-                        field.state.meta.errors[0] instanceof Object
-                          ? (field.state.meta.errors[0] as { message: string })
-                              .message
-                          : field.state.meta.errors[0]
-                      )}
-                    </p>
-                  )}
-              </div>
-            )}
-          </form.Field>
-
-          <form.Field name="password">
-            {(field) => (
-              <div className="flex flex-col gap-1.5">
-                <Label htmlFor="login-password">Password</Label>
-                <PasswordInput
-                  id="login-password"
-                  autoComplete="current-password"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  onBlur={field.handleBlur}
-                />
-                {field.state.meta.isTouched &&
-                  field.state.meta.errors.length > 0 && (
-                    <p className="text-xs text-destructive">
-                      {String(
-                        field.state.meta.errors[0] instanceof Object
-                          ? (field.state.meta.errors[0] as { message: string })
-                              .message
-                          : field.state.meta.errors[0]
-                      )}
-                    </p>
-                  )}
-              </div>
-            )}
-          </form.Field>
-
-          <button
-            type="button"
-            className="self-end text-xs text-muted-foreground hover:underline"
-          >
-            Forgot password?
-          </button>
-
-          {serverError && (
-            <p className="text-sm text-destructive">{serverError}</p>
-          )}
-
-          <form.Subscribe selector={(s) => s.isSubmitting}>
-            {(isSubmitting) => (
-              <Button type="submit" disabled={isSubmitting} className="w-full">
-                {isSubmitting ? '로그인 중...' : 'Log in'}
+            <div className="flex w-full flex-col gap-5">
+              <Button
+                variant="outline"
+                type="button"
+                className="h-14 w-full justify-center rounded-[10px] border-[#b3b3b3] px-2.5 py-5 text-[#333]"
+                onClick={() =>
+                  signIn.social({
+                    provider: 'google',
+                    callbackURL: '/candidate/profile',
+                  })
+                }
+              >
+                <span className="flex w-64 items-center gap-5">
+                  <Icon name="google" size={32} alt="Google" />
+                  <span className="flex gap-1 text-lg font-medium">
+                    <span>Log in</span>
+                    <span>with Google</span>
+                  </span>
+                </span>
               </Button>
-            )}
-          </form.Subscribe>
-        </form>
+              <Button
+                variant="outline"
+                type="button"
+                className="h-14 w-full justify-center rounded-[10px] border-[#b3b3b3] px-2.5 py-5 text-[#333]"
+                onClick={() =>
+                  signIn.social({
+                    provider: 'facebook',
+                    callbackURL: '/candidate/profile',
+                  })
+                }
+              >
+                <span className="flex w-64 items-center gap-5">
+                  <Icon name="facebook" size={32} alt="Facebook" />
+                  <span className="flex gap-1 text-lg font-medium">
+                    <span>Log in</span>
+                    <span>with Facebook</span>
+                  </span>
+                </span>
+              </Button>
+            </div>
+
+            <div className="flex w-full items-center gap-2.5 overflow-hidden">
+              <div className="h-px flex-1 bg-[#b3b3b3]" />
+              <span className="text-sm font-medium text-[#999]">or</span>
+              <div className="h-px flex-1 bg-[#b3b3b3]" />
+            </div>
+
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                form.handleSubmit();
+              }}
+              className="flex w-full flex-col gap-5"
+            >
+              <form.Field name="email">
+                {(field) => (
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="login-email" className="sr-only">
+                      Email
+                    </Label>
+                    <div className="flex items-center gap-2.5">
+                      <Icon name="mail" size={24} />
+                      <FormInput
+                        id="login-email"
+                        type="email"
+                        autoComplete="email"
+                        value={field.state.value}
+                        onChange={(e) => field.handleChange(e.target.value)}
+                        onBlur={field.handleBlur}
+                        placeholder="Vridge1234@gmail.com"
+                        filled
+                        className="h-14 text-lg placeholder:text-[#999]"
+                      />
+                    </div>
+                    {field.state.meta.isTouched &&
+                      field.state.meta.errors.length > 0 && (
+                        <p className="text-xs text-destructive">
+                          {String(
+                            field.state.meta.errors[0] instanceof Object
+                              ? (
+                                  field.state.meta.errors[0] as {
+                                    message: string;
+                                  }
+                                ).message
+                              : field.state.meta.errors[0]
+                          )}
+                        </p>
+                      )}
+                  </div>
+                )}
+              </form.Field>
+
+              <form.Field name="password">
+                {(field) => (
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="login-password" className="sr-only">
+                      Password
+                    </Label>
+                    <PasswordInput
+                      id="login-password"
+                      autoComplete="current-password"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                      onBlur={field.handleBlur}
+                      placeholder="Password"
+                      className="h-14"
+                    />
+                    {field.state.meta.isTouched &&
+                      field.state.meta.errors.length > 0 && (
+                        <p className="text-xs text-destructive">
+                          {String(
+                            field.state.meta.errors[0] instanceof Object
+                              ? (
+                                  field.state.meta.errors[0] as {
+                                    message: string;
+                                  }
+                                ).message
+                              : field.state.meta.errors[0]
+                          )}
+                        </p>
+                      )}
+                  </div>
+                )}
+              </form.Field>
+
+              <button
+                type="button"
+                className="self-end text-right text-sm font-medium text-[#666] hover:underline"
+              >
+                Forgot password?
+              </button>
+
+              {serverError && (
+                <p className="text-sm text-destructive">{serverError}</p>
+              )}
+
+              <form.Subscribe
+                selector={(s) => ({
+                  isSubmitting: s.isSubmitting,
+                  email: s.values.email,
+                  password: s.values.password,
+                })}
+              >
+                {({ isSubmitting, email, password }) => {
+                  const disabled = isSubmitting || !email || !password;
+                  return (
+                    <Button
+                      type="submit"
+                      variant={disabled ? 'brand-disabled' : 'brand'}
+                      size="brand-lg"
+                      disabled={disabled}
+                      className="w-full"
+                    >
+                      {isSubmitting ? '로그인 중...' : 'Continue'}
+                    </Button>
+                  );
+                }}
+              </form.Subscribe>
+            </form>
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/features/auth/ui/password-input.tsx
+++ b/features/auth/ui/password-input.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import Image from 'next/image';
 import { cn } from '@/lib/utils';
+import { Icon } from '@/components/ui/icon';
 
 type PasswordInputProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -21,13 +21,7 @@ export function PasswordInput({ id, className, ...props }: PasswordInputProps) {
         className
       )}
     >
-      <Image
-        src="/icons/password.svg"
-        alt="lock"
-        width={24}
-        height={24}
-        className="shrink-0"
-      />
+      <Icon name="password" size={24} alt="lock" className="shrink-0" />
       <input
         id={id}
         type={show ? 'text' : 'password'}
@@ -40,12 +34,7 @@ export function PasswordInput({ id, className, ...props }: PasswordInputProps) {
         className="shrink-0"
         aria-label={show ? '비밀번호 숨기기' : '비밀번호 보기'}
       >
-        <Image
-          src={show ? '/icons/hidden.svg' : '/icons/show.svg'}
-          alt=""
-          width={24}
-          height={24}
-        />
+        <Icon name={show ? 'hidden' : 'show'} size={24} />
       </button>
     </div>
   );

--- a/features/auth/ui/signup-modal.tsx
+++ b/features/auth/ui/signup-modal.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
-import Image from 'next/image';
 import {
   Dialog,
   DialogContent,
-  DialogHeader,
+  DialogDescription,
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Label } from '@/components/ui/label';
-import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { FormInput } from '@/components/ui/form-input';
+import { Icon } from '@/components/ui/icon';
 import { signIn, signUp } from '@/lib/infrastructure/auth-client';
 import { useAuthModal } from '../model/use-auth-modal';
 import { PasswordInput } from './password-input';
@@ -30,7 +30,6 @@ export function SignupModal() {
   const [privacyChecked, setPrivacyChecked] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
 
-  // 모달 닫힐 때 step 1으로 리셋
   useEffect(() => {
     if (!isSignupOpen) {
       setTimeout(() => {
@@ -51,9 +50,7 @@ export function SignupModal() {
         email: value.email,
         password: value.password,
         fetchOptions: {
-          onSuccess: () => {
-            setStep('success');
-          },
+          onSuccess: () => setStep('success'),
           onError: (ctx) => {
             setServerError(
               (ctx.error as { message?: string })?.message ??
@@ -67,181 +64,240 @@ export function SignupModal() {
 
   return (
     <Dialog open={isSignupOpen} onOpenChange={(open) => !open && closeAll()}>
-      <DialogContent className="sm:max-w-sm">
-        {step === 'method' && (
-          <>
-            <DialogHeader>
-              <DialogTitle>회원가입</DialogTitle>
-              <p className="text-sm text-muted-foreground">
-                이미 계정이 있으신가요?{' '}
-                <button
-                  type="button"
-                  onClick={openLogin}
-                  className="font-medium text-brand hover:underline"
-                >
-                  Log in
-                </button>
-              </p>
-            </DialogHeader>
-
-            <div className="flex flex-col gap-3">
-              <Button
-                variant="outline"
+      <DialogContent
+        showCloseButton={false}
+        className="w-[712px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-[20px] border-0 bg-white p-0 shadow-[0_0_15px_7px_rgba(255,149,84,0.07)]"
+      >
+        <div className="flex flex-col items-center gap-10 px-5 pt-5 pb-20">
+          <div className="flex w-full items-center justify-between">
+            <p className="text-sm text-[#666]">
+              Have an account?{' '}
+              <button
                 type="button"
-                className="w-full gap-2"
-                onClick={() =>
-                  signIn.social({
-                    provider: 'google',
-                    callbackURL: '/candidate/profile',
-                  })
-                }
+                onClick={openLogin}
+                className="underline underline-offset-2"
               >
-                <Image src="/icons/google.svg" alt="" width={20} height={20} />
-                Sign up with Google
-              </Button>
-              <Button
-                variant="outline"
-                type="button"
-                className="w-full gap-2"
-                onClick={() =>
-                  signIn.social({
-                    provider: 'facebook',
-                    callbackURL: '/candidate/profile',
-                  })
-                }
-              >
-                <Image
-                  src="/icons/facebook.svg"
-                  alt=""
-                  width={20}
-                  height={20}
-                />
-                Sign up with Facebook
-              </Button>
-              <Button
-                variant="outline"
-                type="button"
-                className="w-full gap-2"
-                onClick={() => setStep('form')}
-              >
-                <Image
-                  src="/icons/email-at.svg"
-                  alt=""
-                  width={20}
-                  height={20}
-                />
-                Sign up with Email
-              </Button>
-            </div>
-          </>
-        )}
-
-        {step === 'form' && (
-          <>
-            <DialogHeader>
-              <DialogTitle>이메일로 가입</DialogTitle>
-            </DialogHeader>
-
-            <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                form.handleSubmit();
-              }}
-              className="flex flex-col gap-4"
-            >
-              <form.Field name="email">
-                {(field) => (
-                  <div className="flex flex-col gap-1.5">
-                    <Label htmlFor="signup-email">Email</Label>
-                    <Input
-                      id="signup-email"
-                      type="email"
-                      autoComplete="email"
-                      value={field.state.value}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      onBlur={field.handleBlur}
-                    />
-                    {field.state.meta.isTouched &&
-                      field.state.meta.errors.length > 0 && (
-                        <p className="text-xs text-destructive">
-                          {String(
-                            field.state.meta.errors[0] instanceof Object
-                              ? (
-                                  field.state.meta.errors[0] as {
-                                    message: string;
-                                  }
-                                ).message
-                              : field.state.meta.errors[0]
-                          )}
-                        </p>
-                      )}
-                  </div>
-                )}
-              </form.Field>
-
-              <form.Field name="password">
-                {(field) => (
-                  <div className="flex flex-col gap-1.5">
-                    <Label htmlFor="signup-password">Password</Label>
-                    <PasswordInput
-                      id="signup-password"
-                      autoComplete="new-password"
-                      value={field.state.value}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      onBlur={field.handleBlur}
-                    />
-                    <p
-                      className={`text-xs ${
-                        field.state.value.length >= 8
-                          ? 'text-green-600'
-                          : 'text-muted-foreground'
-                      }`}
-                    >
-                      {field.state.value.length >= 8 ? '✓' : '✗'} 8자 이상
-                    </p>
-                  </div>
-                )}
-              </form.Field>
-
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={privacyChecked}
-                  onChange={(e) => setPrivacyChecked(e.target.checked)}
-                />
-                개인정보 처리방침에 동의합니다
-              </label>
-
-              {serverError && (
-                <p className="text-sm text-destructive">{serverError}</p>
-              )}
-
-              <form.Subscribe selector={(s) => s.isSubmitting}>
-                {(isSubmitting) => (
-                  <Button
-                    type="submit"
-                    disabled={isSubmitting || !privacyChecked}
-                    className="w-full"
-                  >
-                    {isSubmitting ? '가입 중...' : 'Sign Up'}
-                  </Button>
-                )}
-              </form.Subscribe>
-            </form>
-          </>
-        )}
-
-        {step === 'success' && (
-          <div className="flex flex-col items-center gap-4 py-6">
-            <h2 className="text-lg font-semibold">가입 완료!</h2>
-            <p className="text-sm text-muted-foreground">
-              회원가입이 완료되었습니다.
+                Log in
+              </button>
             </p>
-            <Button onClick={closeAll} className="w-full">
-              닫기
-            </Button>
+            <button
+              type="button"
+              onClick={closeAll}
+              aria-label="Close signup modal"
+              className="rounded-sm p-1 text-[#1a1a1a] hover:bg-[#f5f5f5]"
+            >
+              <Icon name="close" size={16} />
+            </button>
           </div>
-        )}
+
+          <div className="flex w-full max-w-[520px] flex-col items-center gap-10">
+            <DialogDescription className="sr-only">
+              Create an account or continue with a social login provider.
+            </DialogDescription>
+            {step === 'method' && (
+              <>
+                <DialogTitle className="text-2xl font-bold text-[#1f1f1f]">
+                  Sign Up
+                </DialogTitle>
+
+                <div className="flex w-full flex-col gap-5">
+                  <Button
+                    variant="outline"
+                    type="button"
+                    className="h-14 w-full justify-center rounded-[10px] border-[#b3b3b3] px-2.5 py-5 text-[#333]"
+                    onClick={() =>
+                      signIn.social({
+                        provider: 'google',
+                        callbackURL: '/candidate/profile',
+                      })
+                    }
+                  >
+                    <span className="flex w-64 items-center gap-5">
+                      <Icon name="google" size={32} alt="Google" />
+                      <span className="flex gap-1 text-lg font-medium">
+                        <span>Sign up</span>
+                        <span>with Google</span>
+                      </span>
+                    </span>
+                  </Button>
+
+                  <Button
+                    variant="outline"
+                    type="button"
+                    className="h-14 w-full justify-center rounded-[10px] border-[#b3b3b3] px-2.5 py-5 text-[#333]"
+                    onClick={() =>
+                      signIn.social({
+                        provider: 'facebook',
+                        callbackURL: '/candidate/profile',
+                      })
+                    }
+                  >
+                    <span className="flex w-64 items-center gap-5">
+                      <Icon name="facebook" size={32} alt="Facebook" />
+                      <span className="flex gap-1 text-lg font-medium">
+                        <span>Sign up</span>
+                        <span>with Facebook</span>
+                      </span>
+                    </span>
+                  </Button>
+                </div>
+
+                <div className="flex w-full items-center gap-2.5 overflow-hidden">
+                  <div className="h-px flex-1 bg-[#b3b3b3]" />
+                  <span className="text-sm font-medium text-[#999]">or</span>
+                  <div className="h-px flex-1 bg-[#b3b3b3]" />
+                </div>
+
+                <Button
+                  variant="outline"
+                  type="button"
+                  className="h-14 w-full justify-center rounded-[10px] border-[#b3b3b3] px-2.5 py-5 text-[#333]"
+                  onClick={() => setStep('form')}
+                >
+                  <span className="flex w-64 items-center gap-5">
+                    <Icon name="email-at" size={32} alt="Email" />
+                    <span className="flex gap-1 text-lg font-medium">
+                      <span>Sign up</span>
+                      <span>with E-mail</span>
+                    </span>
+                  </span>
+                </Button>
+              </>
+            )}
+
+            {step === 'form' && (
+              <>
+                <DialogTitle className="text-2xl font-bold text-[#1f1f1f]">
+                  Sign Up
+                </DialogTitle>
+
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    form.handleSubmit();
+                  }}
+                  className="flex w-full flex-col gap-5"
+                >
+                  <form.Field name="email">
+                    {(field) => (
+                      <div className="flex flex-col gap-1.5">
+                        <Label htmlFor="signup-email" className="sr-only">
+                          Email
+                        </Label>
+                        <div className="flex items-center gap-2.5">
+                          <Icon name="mail" size={24} />
+                          <FormInput
+                            id="signup-email"
+                            type="email"
+                            autoComplete="email"
+                            value={field.state.value}
+                            onChange={(e) => field.handleChange(e.target.value)}
+                            onBlur={field.handleBlur}
+                            placeholder="E-mail"
+                            filled
+                            className="h-14 text-lg placeholder:text-[#999]"
+                          />
+                        </div>
+                        {field.state.meta.isTouched &&
+                          field.state.meta.errors.length > 0 && (
+                            <p className="text-xs text-destructive">
+                              {String(
+                                field.state.meta.errors[0] instanceof Object
+                                  ? (
+                                      field.state.meta.errors[0] as {
+                                        message: string;
+                                      }
+                                    ).message
+                                  : field.state.meta.errors[0]
+                              )}
+                            </p>
+                          )}
+                      </div>
+                    )}
+                  </form.Field>
+
+                  <form.Field name="password">
+                    {(field) => (
+                      <div className="flex flex-col gap-1.5">
+                        <Label htmlFor="signup-password" className="sr-only">
+                          Password
+                        </Label>
+                        <PasswordInput
+                          id="signup-password"
+                          autoComplete="new-password"
+                          value={field.state.value}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                          onBlur={field.handleBlur}
+                          placeholder="Password"
+                          className="h-14"
+                        />
+                        <p
+                          className={`text-xs ${
+                            field.state.value.length >= 8
+                              ? 'text-green-600'
+                              : 'text-muted-foreground'
+                          }`}
+                        >
+                          {field.state.value.length >= 8 ? '✓' : '✗'} 8자 이상
+                        </p>
+                      </div>
+                    )}
+                  </form.Field>
+
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={privacyChecked}
+                      onChange={(e) => setPrivacyChecked(e.target.checked)}
+                    />
+                    개인정보 처리방침에 동의합니다
+                  </label>
+
+                  {serverError && (
+                    <p className="text-sm text-destructive">{serverError}</p>
+                  )}
+
+                  <form.Subscribe selector={(s) => s.isSubmitting}>
+                    {(isSubmitting) => (
+                      <Button
+                        type="submit"
+                        variant={
+                          isSubmitting || !privacyChecked
+                            ? 'brand-disabled'
+                            : 'brand'
+                        }
+                        size="brand-lg"
+                        disabled={isSubmitting || !privacyChecked}
+                        className="w-full"
+                      >
+                        {isSubmitting ? '가입 중...' : 'Sign Up'}
+                      </Button>
+                    )}
+                  </form.Subscribe>
+                </form>
+              </>
+            )}
+
+            {step === 'success' && (
+              <div className="flex w-full flex-col items-center gap-4 py-6">
+                <DialogTitle className="text-lg font-semibold">
+                  가입 완료!
+                </DialogTitle>
+                <p className="text-sm text-muted-foreground">
+                  회원가입이 완료되었습니다.
+                </p>
+                <Button
+                  onClick={closeAll}
+                  variant="brand"
+                  size="brand-lg"
+                  className="w-full"
+                >
+                  닫기
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/features/profile-edit/model/use-unsaved-changes-guard.ts
+++ b/features/profile-edit/model/use-unsaved-changes-guard.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+const LEAVE_MESSAGE =
+  '저장되지 않은 변경사항이 있습니다. 페이지를 벗어나시겠어요?';
+
+export function useUnsavedChangesGuard(isDirty: boolean) {
+  const dirtyRef = useRef(isDirty);
+
+  useEffect(() => {
+    dirtyRef.current = isDirty;
+  }, [isDirty]);
+
+  useEffect(() => {
+    function shouldBlock() {
+      return dirtyRef.current;
+    }
+
+    function confirmLeave() {
+      return window.confirm(LEAVE_MESSAGE);
+    }
+
+    function handleBeforeUnload(event: BeforeUnloadEvent) {
+      if (!shouldBlock()) return;
+      event.preventDefault();
+      event.returnValue = '';
+    }
+
+    function handleClickCapture(event: MouseEvent) {
+      if (!shouldBlock()) return;
+
+      const target = event.target as HTMLElement | null;
+      const anchor = target?.closest('a[href]') as HTMLAnchorElement | null;
+      if (!anchor) return;
+
+      const href = anchor.getAttribute('href');
+      if (!href || href.startsWith('#') || href.startsWith('javascript:')) {
+        return;
+      }
+
+      const currentUrl = new URL(window.location.href);
+      const nextUrl = new URL(anchor.href, currentUrl);
+      if (currentUrl.href === nextUrl.href) return;
+
+      if (!confirmLeave()) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }
+
+    function handlePopState() {
+      if (!shouldBlock()) return;
+      if (confirmLeave()) return;
+      window.history.pushState(null, '', window.location.href);
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    document.addEventListener('click', handleClickCapture, true);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      document.removeEventListener('click', handleClickCapture, true);
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
+}

--- a/todo.md
+++ b/todo.md
@@ -81,4 +81,4 @@
 
 - **테스트**: 424개 통과 (63 suite)
 - **타입 체크**: `tsc --noEmit` 클린
-- **브랜치**: `feat/prompt23-announcement-slug`
+- **브랜치**: `feat/prompt23-ui-alignment`


### PR DESCRIPTION
## 개요
Prompt 23 마무리 작업으로 프로필 편집/인증 모달 UI를 피그마 가이드에 맞춰 정렬하고, 편집 저장 흐름을 전역 draft 방식으로 개선했습니다.

## 구현 내용
- 프로필 편집 페이지를 Server + Client 오케스트레이션 구조로 재구성
- 전역 draft/baseline 비교 기반 Save 바 및 단일 저장 파이프라인 추가
- 미저장 이탈 방지 가드 추가(beforeunload, 링크 이동, 뒤로가기)
- 로그인/회원가입 모달을 피그마 구조로 정렬(기존 인증 동작 유지)
- Prompt 20 공유 컴포넌트 재사용 강화(FormInput, Icon, Button, ToggleSwitch, SectionTitle 등)
- 문서 업데이트(implementation-plan-p5, todo)

## 변경 파일
- 총 9개 파일 변경
- 주요 파일:
  - app/(dashboard)/candidate/profile/edit/page.tsx
  - features/profile-edit/ui/profile-edit-page-client.tsx
  - features/profile-edit/model/use-unsaved-changes-guard.ts
  - features/auth/ui/login-modal.tsx
  - features/auth/ui/signup-modal.tsx
  - features/auth/ui/password-input.tsx
  - __tests__/features/auth/login-modal.test.tsx
  - docs/implementation-plan-p5.md
  - todo.md

## 검증
- pnpm test: 424 tests 통과 (63 suite)
- pnpm tsc --noEmit: 통과