### PR TITLE
feat: Prompt 23 후속 컴포넌트 정렬 (Badge→Chip)

### DIFF
--- a/__tests__/entities/profile/career-list.test.tsx
+++ b/__tests__/entities/profile/career-list.test.tsx
@@ -26,9 +26,10 @@ describe('CareerList', () => {
     expect(screen.getByText('Software Engineer')).toBeInTheDocument();
   });
 
-  it('renders employment type label as badge', () => {
-    render(<CareerList careers={[baseCareer]} />);
+  it('renders employment type label as chip', () => {
+    const { container } = render(<CareerList careers={[baseCareer]} />);
     expect(screen.getByText('정규직')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="chip"]')).toHaveLength(1);
   });
 
   it('formats startDate as YYYY.MM', () => {
@@ -54,7 +55,8 @@ describe('CareerList', () => {
 
   it('renders experience level when provided', () => {
     const career = { ...baseCareer, experienceLevel: 'SENIOR' };
-    render(<CareerList careers={[career]} />);
+    const { container } = render(<CareerList careers={[career]} />);
     expect(screen.getByText('Senior')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="chip"]')).toHaveLength(2);
   });
 });

--- a/__tests__/entities/profile/education-list.test.tsx
+++ b/__tests__/entities/profile/education-list.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { EducationList } from '@/entities/profile/ui/education-list';
+
+const baseEducation = {
+  id: 'edu-1',
+  institutionName: '서울대학교',
+  educationType: 'higher_bachelor',
+  field: 'Computer Science',
+  graduationStatus: 'GRADUATED',
+  startDate: new Date('2018-03-01'),
+  endDate: new Date('2022-02-01'),
+  sortOrder: 0,
+};
+
+describe('EducationList', () => {
+  it('기관/유형/상태/기간 렌더링', () => {
+    render(<EducationList educations={[baseEducation]} />);
+    expect(screen.getByText('서울대학교')).toBeInTheDocument();
+    expect(screen.getByText('학사')).toBeInTheDocument();
+    expect(screen.getByText('졸업')).toBeInTheDocument();
+    expect(screen.getByText(/2018\.03/)).toBeInTheDocument();
+    expect(screen.getByText(/2022\.02/)).toBeInTheDocument();
+  });
+
+  it('유형/상태를 chip으로 렌더링', () => {
+    const { container } = render(
+      <EducationList educations={[baseEducation]} />
+    );
+    expect(container.querySelectorAll('[data-slot="chip"]')).toHaveLength(2);
+  });
+
+  it('전공이 있으면 전공 렌더링', () => {
+    render(<EducationList educations={[baseEducation]} />);
+    expect(screen.getByText('Computer Science')).toBeInTheDocument();
+  });
+
+  it('endDate가 없으면 현재 렌더링', () => {
+    render(
+      <EducationList educations={[{ ...baseEducation, endDate: null }]} />
+    );
+    expect(screen.getByText(/현재/)).toBeInTheDocument();
+  });
+
+  it('알 수 없는 유형/상태는 원본 값 fallback', () => {
+    render(
+      <EducationList
+        educations={[
+          {
+            ...baseEducation,
+            educationType: 'custom_type',
+            graduationStatus: 'custom_status',
+          },
+        ]}
+      />
+    );
+    expect(screen.getByText('custom_type')).toBeInTheDocument();
+    expect(screen.getByText('custom_status')).toBeInTheDocument();
+  });
+
+  it('빈 목록이면 empty 상태 렌더링', () => {
+    render(<EducationList educations={[]} />);
+    expect(screen.getByText('학력 없음')).toBeInTheDocument();
+  });
+});

--- a/__tests__/entities/profile/language-list.test.tsx
+++ b/__tests__/entities/profile/language-list.test.tsx
@@ -9,10 +9,11 @@ const baseLanguage = {
 };
 
 describe('LanguageList', () => {
-  it('언어와 숙련도 렌더링', () => {
-    render(<LanguageList languages={[baseLanguage]} />);
+  it('언어와 숙련도 렌더링 + 숙련도 chip 사용', () => {
+    const { container } = render(<LanguageList languages={[baseLanguage]} />);
     expect(screen.getByText('English')).toBeInTheDocument();
     expect(screen.getByText('업무 가능')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="chip"]')).toHaveLength(1);
   });
 
   it('testName/testScore 함께 있으면 점수 정보 렌더링', () => {

--- a/__tests__/entities/profile/skill-badges.test.tsx
+++ b/__tests__/entities/profile/skill-badges.test.tsx
@@ -7,9 +7,10 @@ describe('SkillBadges', () => {
       { skill: { displayNameEn: 'TypeScript' } },
       { skill: { displayNameEn: 'React' } },
     ];
-    render(<SkillBadges skills={skills} />);
+    const { container } = render(<SkillBadges skills={skills} />);
     expect(screen.getByText('TypeScript')).toBeInTheDocument();
     expect(screen.getByText('React')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="chip"]')).toHaveLength(2);
   });
 
   it('renders empty state when skills is empty', () => {

--- a/__tests__/features/job-browse/job-sort-control.test.tsx
+++ b/__tests__/features/job-browse/job-sort-control.test.tsx
@@ -23,6 +23,12 @@ describe('JobSortControl', () => {
     ).toBeInTheDocument();
   });
 
+  it('compact raw select 스타일을 유지한다', () => {
+    render(<JobSortControl />);
+    const select = screen.getByRole('combobox', { name: 'Sort by' });
+    expect(select).toHaveClass('appearance-none');
+  });
+
   it('sort 파라미터 없으면 기본값 updated_desc 선택', () => {
     render(<JobSortControl />);
     const select = screen.getByRole('combobox', { name: 'Sort by' });

--- a/docs/implementation-plan-p5.md
+++ b/docs/implementation-plan-p5.md
@@ -319,8 +319,10 @@ P24 (Polish + E2E) depends on all
 - 미저장 이탈 방지 가드를 추가했다 (`beforeunload`, 링크 클릭, 뒤로가기 confirm).
 - 로그인/회원가입 모달을 Figma 구조에 맞게 재정렬하면서 기존 인증 동작을 유지했다 (소셜 로그인, 이메일/비밀번호, 3-step signup).
 - Prompt 20 공유 컴포넌트 재사용을 강화했다 (`FormInput`, `Icon`, `Button`, `ToggleSwitch`, `SectionTitle`, `DatePicker`, `FormDropdown`, `SearchBar`, `Chip`, `DialcodePicker`).
+- 활성 프로필 엔티티 표시 컴포넌트 4곳의 `Badge`를 `Chip`으로 정렬했다 (`skill-badges`, `career-list`, `education-list`, `language-list`).
+- `education-list` 테스트를 신규 추가하고, 관련 엔티티/정렬 컨트롤 테스트에 `Chip` 및 compact select 가드 검증을 추가했다.
 - 테스트를 확장했다: 공지사항 페이지/상세, 후보자 slug 페이지, 지원 목록 페이지, nav/proxy/profile/announcement use-case·action.
-- 전체 검증 완료: `63 suite`, `424 tests`, `tsc --noEmit` 클린.
+- 전체 검증 완료: `64 suite`, `431 tests`, `tsc --noEmit` 클린.
 
 ---
 

--- a/entities/profile/ui/career-list.tsx
+++ b/entities/profile/ui/career-list.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@/components/ui/badge';
+import { Chip } from '@/components/ui/chip';
 import {
   formatDate,
   EMPLOYMENT_TYPE_LABELS,
@@ -33,15 +33,23 @@ export function CareerList({ careers }: Props) {
         <li key={career.id} className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
             <span className="font-semibold">{career.companyName}</span>
-            <Badge variant="secondary">
-              {EMPLOYMENT_TYPE_LABELS[career.employmentType] ??
-                career.employmentType}
-            </Badge>
+            <Chip
+              label={
+                EMPLOYMENT_TYPE_LABELS[career.employmentType] ??
+                career.employmentType
+              }
+              variant="displayed"
+              size="sm"
+            />
             {career.experienceLevel && (
-              <Badge variant="outline">
-                {EXPERIENCE_LEVEL_LABELS[career.experienceLevel] ??
-                  career.experienceLevel}
-              </Badge>
+              <Chip
+                label={
+                  EXPERIENCE_LEVEL_LABELS[career.experienceLevel] ??
+                  career.experienceLevel
+                }
+                variant="displayed"
+                size="sm"
+              />
             )}
           </div>
           <span className="text-sm">{career.positionTitle}</span>

--- a/entities/profile/ui/education-list.tsx
+++ b/entities/profile/ui/education-list.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@/components/ui/badge';
+import { Chip } from '@/components/ui/chip';
 import {
   formatDate,
   EDUCATION_TYPE_LABELS,
@@ -31,17 +31,21 @@ export function EducationList({ educations }: Props) {
         <li key={edu.id} className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
             <span className="font-semibold">{edu.institutionName}</span>
-            <Badge variant="secondary">
-              {EDUCATION_TYPE_LABELS[edu.educationType] ?? edu.educationType}
-            </Badge>
-            <Badge
-              variant={
-                edu.graduationStatus === 'GRADUATED' ? 'default' : 'outline'
+            <Chip
+              label={
+                EDUCATION_TYPE_LABELS[edu.educationType] ?? edu.educationType
               }
-            >
-              {GRADUATION_STATUS_LABELS[edu.graduationStatus] ??
-                edu.graduationStatus}
-            </Badge>
+              variant="displayed"
+              size="sm"
+            />
+            <Chip
+              label={
+                GRADUATION_STATUS_LABELS[edu.graduationStatus] ??
+                edu.graduationStatus
+              }
+              variant="displayed"
+              size="sm"
+            />
           </div>
           {edu.field && (
             <span className="text-sm text-muted-foreground">{edu.field}</span>

--- a/entities/profile/ui/language-list.tsx
+++ b/entities/profile/ui/language-list.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@/components/ui/badge';
+import { Chip } from '@/components/ui/chip';
 import { PROFICIENCY_LABELS } from './_utils';
 
 type Language = {
@@ -24,9 +24,11 @@ export function LanguageList({ languages }: Props) {
       {languages.map((lang) => (
         <li key={lang.id} className="flex items-center gap-2">
           <span>{lang.language}</span>
-          <Badge variant="secondary">
-            {PROFICIENCY_LABELS[lang.proficiency] ?? lang.proficiency}
-          </Badge>
+          <Chip
+            label={PROFICIENCY_LABELS[lang.proficiency] ?? lang.proficiency}
+            variant="displayed"
+            size="sm"
+          />
           {lang.testName && lang.testScore && (
             <span className="text-sm text-muted-foreground">
               {lang.testName} · {lang.testScore}

--- a/entities/profile/ui/skill-badges.tsx
+++ b/entities/profile/ui/skill-badges.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@/components/ui/badge';
+import { Chip } from '@/components/ui/chip';
 
 type Skill = {
   skill: { displayNameEn: string };
@@ -16,9 +16,12 @@ export function SkillBadges({ skills }: Props) {
   return (
     <div className="flex flex-wrap gap-2">
       {skills.map((s, i) => (
-        <Badge key={i} variant="secondary">
-          {s.skill.displayNameEn}
-        </Badge>
+        <Chip
+          key={`${s.skill.displayNameEn}-${i}`}
+          label={s.skill.displayNameEn}
+          variant="displayed"
+          size="md"
+        />
       ))}
     </div>
   );

--- a/todo.md
+++ b/todo.md
@@ -79,6 +79,6 @@
 
 ## 현재 상태
 
-- **테스트**: 424개 통과 (63 suite)
+- **테스트**: 431개 통과 (64 suite)
 - **타입 체크**: `tsc --noEmit` 클린
-- **브랜치**: `feat/prompt23-ui-alignment`
+- **브랜치**: `feat/prompt23-active-component-alignment`


### PR DESCRIPTION
## 개요
Prompt 23 후속 작업으로 활성 화면 범위(Items 20~26) 컴포넌트 정렬을 수행했습니다.

## 구현 내용
- 프로필 엔티티 표시 컴포넌트 4곳에서 Badge를 Chip으로 교체
  - entities/profile/ui/skill-badges.tsx
  - entities/profile/ui/career-list.tsx
  - entities/profile/ui/education-list.tsx
  - entities/profile/ui/language-list.tsx
- job-sort-control은 합의대로 compact raw select 구조를 유지하고, 회귀 방지 테스트 가드 추가
- 테스트 보강(TDD)
  - education-list 테스트 신규 추가
  - career/language/skill-badges 테스트에 chip 렌더링 검증 추가
  - sort-control compact select 가드 검증 추가
- 문서 업데이트
  - docs/implementation-plan-p5.md Prompt 23 결과 섹션 갱신
  - todo.md 현재 상태(테스트/브랜치) 갱신

## 변경 파일
총 11개 파일 변경
- 코드/테스트: 9개
- 문서: 2개

## 검증 결과
- pnpm test: 64 suite, 431 tests 통과
- pnpm tsc --noEmit: 통과
