### PR TITLE
feat: Prompt 24 폴리시 작업 및 로딩/에러 UX 정비

### DIFF
--- a/__tests__/app/loading-pages.test.tsx
+++ b/__tests__/app/loading-pages.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import JobsLoading from '@/app/jobs/loading';
+import JobDetailLoading from '@/app/jobs/[id]/loading';
+import AnnouncementsLoading from '@/app/announcements/loading';
+import AnnouncementDetailLoading from '@/app/announcements/[id]/loading';
+import CandidateApplicationsLoading from '@/app/(dashboard)/candidate/applications/loading';
+import CandidateProfileLoading from '@/app/(dashboard)/candidate/profile/loading';
+
+describe('route loading UI', () => {
+  const cases = [
+    ['jobs 목록', JobsLoading],
+    ['jobs 상세', JobDetailLoading],
+    ['announcements 목록', AnnouncementsLoading],
+    ['announcements 상세', AnnouncementDetailLoading],
+    ['candidate applications', CandidateApplicationsLoading],
+    ['candidate profile', CandidateProfileLoading],
+  ] as const;
+
+  it.each(cases)('%s loading이 스켈레톤을 렌더링한다', (_, Component) => {
+    const { container } = render(<Component />);
+    expect(
+      container.querySelector('[data-slot="skeleton"]')
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/actions/announcements.test.ts
+++ b/__tests__/lib/actions/announcements.test.ts
@@ -41,6 +41,7 @@ describe('getAnnouncements', () => {
     expect(result).toEqual(
       expect.objectContaining({ error: expect.any(String) })
     );
+    expect(result).not.toHaveProperty('errorCode');
     expect(announcementsUC.getAnnouncements).not.toHaveBeenCalled();
   });
 
@@ -76,7 +77,7 @@ describe('getAnnouncementById', () => {
     expect(announcementsUC.getAnnouncementById).toHaveBeenCalledWith('ann-1');
   });
 
-  it('DomainError NOT_FOUND → { error: message }', async () => {
+  it('DomainError NOT_FOUND → { error, errorCode }', async () => {
     const domainErr = new DomainError(
       'NOT_FOUND',
       '공지사항을(를) 찾을 수 없습니다'
@@ -87,7 +88,10 @@ describe('getAnnouncementById', () => {
 
     const result = await getAnnouncementById('nonexistent');
 
-    expect(result).toEqual({ error: '공지사항을(를) 찾을 수 없습니다' });
+    expect(result).toEqual({
+      error: '공지사항을(를) 찾을 수 없습니다',
+      errorCode: 'NOT_FOUND',
+    });
   });
 });
 
@@ -109,7 +113,7 @@ describe('getAnnouncementNeighbors', () => {
     );
   });
 
-  it('DomainError → { error: message }', async () => {
+  it('DomainError → { error, errorCode }', async () => {
     (
       announcementsUC.getAnnouncementNeighbors as unknown as jest.Mock
     ).mockRejectedValue(
@@ -118,6 +122,9 @@ describe('getAnnouncementNeighbors', () => {
 
     const result = await getAnnouncementNeighbors('ann-unknown');
 
-    expect(result).toEqual({ error: '공지사항을 찾을 수 없습니다' });
+    expect(result).toEqual({
+      error: '공지사항을 찾을 수 없습니다',
+      errorCode: 'NOT_FOUND',
+    });
   });
 });

--- a/app/(dashboard)/candidate/applications/loading.tsx
+++ b/app/(dashboard)/candidate/applications/loading.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function CandidateApplicationsLoading() {
+  return (
+    <div className="flex w-full flex-col gap-6 p-6">
+      <Skeleton className="h-9 w-40" />
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <Skeleton className="h-[120px] rounded-[20px]" />
+        <Skeleton className="h-[120px] rounded-[20px]" />
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <Skeleton className="h-9 w-24" />
+        {Array.from({ length: 3 }).map((_, index) => (
+          <div
+            key={`candidate-applications-loading-item-${index}`}
+            className="rounded-[20px] border border-[#ffefe5] bg-white px-[40px] py-[20px]"
+          >
+            <div className="flex items-start gap-4">
+              <Skeleton className="h-[40px] w-[40px]" />
+              <div className="flex flex-1 flex-col gap-2">
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="h-6 w-72" />
+                <Skeleton className="h-4 w-56" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/candidate/profile/loading.tsx
+++ b/app/(dashboard)/candidate/profile/loading.tsx
@@ -1,0 +1,10 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function CandidateProfileLoading() {
+  return (
+    <div className="flex flex-col gap-3 p-6">
+      <Skeleton className="h-8 w-64" />
+      <Skeleton className="h-5 w-80" />
+    </div>
+  );
+}

--- a/app/announcements/[id]/loading.tsx
+++ b/app/announcements/[id]/loading.tsx
@@ -1,0 +1,36 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function AnnouncementDetailLoading() {
+  return (
+    <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-7 px-6 py-10">
+      <Skeleton className="h-6 w-6" />
+
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-10 w-96" />
+        <Skeleton className="h-5 w-48" />
+      </div>
+
+      <div className="bg-neutral-50 rounded-[20px] px-5 py-6">
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-[95%]" />
+          <Skeleton className="h-4 w-[92%]" />
+          <Skeleton className="h-4 w-[90%]" />
+        </div>
+      </div>
+
+      <div className="flex flex-col border-y border-black">
+        {Array.from({ length: 2 }).map((_, index) => (
+          <div
+            key={`announcement-detail-loading-nav-${index}`}
+            className="grid grid-cols-[96px_1fr_192px] items-center gap-4 border-b border-black py-5 last:border-b-0"
+          >
+            <Skeleton className="mx-auto h-5 w-14" />
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="mx-auto h-5 w-20" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/announcements/[id]/not-found.tsx
+++ b/app/announcements/[id]/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function AnnouncementNotFound() {
+  return (
+    <div className="mx-auto flex w-full max-w-[1200px] flex-col items-center gap-3 px-6 py-10 text-center">
+      <h1 className="text-2xl font-semibold text-[#1a1a1a]">
+        공지사항을 찾을 수 없습니다.
+      </h1>
+      <p className="text-sm text-[#666]">
+        삭제되었거나 접근할 수 없는 공지입니다.
+      </p>
+      <Button asChild variant="brand" size="brand-sm">
+        <Link href="/announcements">목록으로 이동</Link>
+      </Button>
+    </div>
+  );
+}

--- a/app/announcements/[id]/page.tsx
+++ b/app/announcements/[id]/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import { Icon } from '@/components/ui/icon';
 import {
@@ -11,6 +12,16 @@ function formatDate(date: Date): string {
   const month = String(date.getUTCMonth() + 1).padStart(2, '0');
   const day = String(date.getUTCDate()).padStart(2, '0');
   return `${year}.${month}.${day}`;
+}
+
+function handleAnnouncementError(result: {
+  error: string;
+  errorCode?: string;
+}): never {
+  if (result.errorCode === 'NOT_FOUND') {
+    notFound();
+  }
+  throw new Error(result.error);
 }
 
 export default async function AnnouncementDetailPage({
@@ -26,11 +37,11 @@ export default async function AnnouncementDetailPage({
   ]);
 
   if ('error' in detailResult) {
-    return <p className="p-6 text-destructive">{detailResult.error}</p>;
+    handleAnnouncementError(detailResult);
   }
 
   if ('error' in neighborsResult) {
-    return <p className="p-6 text-destructive">{neighborsResult.error}</p>;
+    handleAnnouncementError(neighborsResult);
   }
 
   const announcement = detailResult.data;

--- a/app/announcements/error.tsx
+++ b/app/announcements/error.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function AnnouncementsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1200px] flex-col items-center gap-3 px-6 py-10 text-center">
+      <h1 className="text-2xl font-semibold text-[#1a1a1a]">
+        공지사항을 불러오지 못했습니다.
+      </h1>
+      <p className="text-sm text-[#666]">
+        네트워크 상태를 확인한 뒤 다시 시도해 주세요.
+      </p>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="brand-outline"
+          size="brand-sm"
+          onClick={reset}
+        >
+          다시 시도
+        </Button>
+        <Button asChild variant="brand" size="brand-sm">
+          <Link href="/announcements">목록으로 이동</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/announcements/loading.tsx
+++ b/app/announcements/loading.tsx
@@ -1,0 +1,34 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function AnnouncementsLoading() {
+  return (
+    <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-6 px-6 py-10">
+      <Skeleton className="h-9 w-64" />
+
+      <div className="flex flex-col border-t-2 border-black">
+        <div className="grid grid-cols-[96px_1fr_192px] border-b border-black py-4">
+          <Skeleton className="mx-auto h-6 w-10" />
+          <Skeleton className="mx-auto h-6 w-28" />
+          <Skeleton className="mx-auto h-6 w-20" />
+        </div>
+
+        {Array.from({ length: 6 }).map((_, index) => (
+          <div
+            key={`announcements-loading-row-${index}`}
+            className="grid grid-cols-[96px_1fr_192px] items-center gap-4 border-b border-black py-5"
+          >
+            <Skeleton className="mx-auto h-6 w-10" />
+            <Skeleton className="h-6 w-3/4" />
+            <Skeleton className="mx-auto h-6 w-24" />
+          </div>
+        ))}
+      </div>
+
+      <div className="flex items-center justify-center gap-2">
+        <Skeleton className="h-9 w-9 rounded-full" />
+        <Skeleton className="h-9 w-9 rounded-full" />
+        <Skeleton className="h-9 w-9 rounded-full" />
+      </div>
+    </div>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-3xl flex-col items-center justify-center gap-4 px-6 text-center">
+      <h1 className="text-2xl font-semibold text-[#1a1a1a]">
+        문제가 발생했습니다.
+      </h1>
+      <p className="text-sm text-[#666]">잠시 후 다시 시도해 주세요.</p>
+      <Button type="button" variant="brand" size="brand-md" onClick={reset}>
+        다시 시도
+      </Button>
+    </div>
+  );
+}

--- a/app/jobs/[id]/loading.tsx
+++ b/app/jobs/[id]/loading.tsx
@@ -1,0 +1,34 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function JobDetailLoading() {
+  return (
+    <div className="mx-auto flex max-w-5xl gap-8 px-6 py-8">
+      <div className="flex flex-1 flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-6 w-6" />
+          <Skeleton className="h-10 w-[420px]" />
+          <Skeleton className="h-5 w-40" />
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-[92%]" />
+          <Skeleton className="h-4 w-[88%]" />
+          <Skeleton className="h-4 w-[84%]" />
+          <Skeleton className="h-4 w-[90%]" />
+        </div>
+      </div>
+
+      <div className="hidden w-[300px] shrink-0 lg:block">
+        <div className="rounded-[20px] border border-[#b3b3b3] bg-white px-[20px] py-[40px]">
+          <div className="flex flex-col gap-4">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/jobs/loading.tsx
+++ b/app/jobs/loading.tsx
@@ -1,0 +1,38 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function JobsLoading() {
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6 px-6 py-8">
+      <Skeleton className="h-12 w-full" />
+
+      <div className="flex items-start justify-between gap-4">
+        <Skeleton className="h-10 w-72" />
+        <Skeleton className="h-10 w-36" />
+      </div>
+
+      <div className="flex flex-col gap-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div
+            key={`jobs-loading-item-${index}`}
+            className="rounded-[20px] border border-[#ffefe5] bg-white px-[40px] py-[20px]"
+          >
+            <div className="flex items-start gap-4">
+              <Skeleton className="h-[40px] w-[40px]" />
+              <div className="flex flex-1 flex-col gap-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-6 w-72" />
+                <Skeleton className="h-4 w-64" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex items-center justify-center gap-2">
+        <Skeleton className="h-9 w-9 rounded-full" />
+        <Skeleton className="h-9 w-9 rounded-full" />
+        <Skeleton className="h-9 w-9 rounded-full" />
+      </div>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function GlobalNotFound() {
+  return (
+    <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-3xl flex-col items-center justify-center gap-4 px-6 text-center">
+      <h1 className="text-2xl font-semibold text-[#1a1a1a]">
+        페이지를 찾을 수 없습니다.
+      </h1>
+      <p className="text-sm text-[#666]">
+        요청하신 페이지가 없거나 이동되었습니다.
+      </p>
+      <Button asChild variant="brand" size="brand-md">
+        <Link href="/jobs">채용공고로 이동</Link>
+      </Button>
+    </div>
+  );
+}

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -1,285 +1,143 @@
 # 프로젝트 폴더 구조
 
-> 이 문서는 vridge ATS MVP의 폴더 구조를 설명합니다.
+> 이 문서는 현재 `dev` 기준 코드 구조를 기준으로 유지합니다.
 
----
+## 아키텍처 요약
 
-## 아키텍처 개요
-
-- **백엔드**: Clean Architecture — `lib/domain/` → `lib/use-cases/` → `lib/infrastructure/` → `lib/actions/`
-- **프론트엔드**: Feature-Sliced Design (FSD) — `entities/` → `features/` → `widgets/` → `app/`
-- **상태 관리**: 서버 상태 (TanStack Query) / UI 상태 (Zustand)
-- **폼**: TanStack Form + Zod
-- **인증**: BetterAuth (모달 기반, 라우트 그룹 없음)
-
----
+- 백엔드: `lib/domain -> lib/use-cases -> lib/infrastructure -> lib/actions` (Clean Architecture)
+- 프론트엔드: `entities -> features -> widgets -> app` (FSD)
+- 공용 프레젠테이션 유틸: `lib/frontend/presentation.ts`
+- 라우팅: Next.js App Router (`app/`)
 
 ## 루트 구조
 
-```
+```text
 vridge/
-├── app/                    # Next.js App Router (라우팅 + 페이지)
-├── lib/                    # 백엔드 계층 (Clean Architecture)
-├── entities/               # FSD 엔티티 (순수 표시 컴포넌트)
-├── features/               # FSD 기능 (UI + 비즈니스 로직)
-├── widgets/                # FSD 위젯 (복합 컴포넌트)
-├── components/             # shadcn/ui 프리미티브
-├── hooks/                  # 공유 훅
-├── prisma/                 # Prisma 스키마, 시드, 마이그레이션
-├── __tests__/              # 테스트 (소스 구조 미러링)
-├── docs/                   # 프로젝트 문서
-├── stories/                # Storybook 스토리 (초기 보일러플레이트)
-├── public/                 # 정적 에셋
-├── proxy.ts                # 인증 미들웨어 (함수명: proxy)
-└── [설정 파일들]
+├── app/
+├── lib/
+├── entities/
+├── features/
+├── widgets/
+├── components/
+├── hooks/
+├── prisma/
+├── __tests__/
+├── docs/
+├── public/
+├── proxy.ts
+└── 설정 파일들
 ```
 
----
+## Next.js 라우트 구조 (`app/`)
 
-## 백엔드 — Clean Architecture (`lib/`)
-
-### 흐름
-
-```
-Server Action → Zod 검증 → 권한 확인 (domain) → use-case → Prisma → 결과 반환
-```
-
-### `lib/domain/` — 순수 도메인 계층
-
-인프라 import 없는 순수 비즈니스 규칙.
-
-```
-lib/domain/
-├── authorization.ts    # AppRole 타입, assertOwnership, assertRole,
-│                       # canViewCandidate, assertCanViewCandidate
-│                       # (ReachabilityChecker DI로 도메인 순수성 유지)
-└── errors.ts           # DomainError 클래스 + 팩토리 (notFound, forbidden, conflict)
-```
-
-### `lib/infrastructure/` — 인프라 계층
-
-외부 서비스 연결 (DB, 인증).
-
-```
-lib/infrastructure/
-├── db.ts               # Prisma 클라이언트 싱글턴 (PrismaPg 어댑터)
-├── auth.ts             # BetterAuth 서버 인스턴스 + signup hook
-├── auth-client.ts      # BetterAuth 브라우저 클라이언트
-└── auth-utils.ts       # getCurrentUser, requireUser, requireRole
-```
-
-### `lib/use-cases/` — 비즈니스 로직
-
-Prisma 직접 호출 (MVP에서 repository 레이어 생략).
-
-```
-lib/use-cases/
-├── profile.ts          # 프로필 CRUD (18개 함수 + 자격증 CRUD 3개)
-├── applications.ts     # 지원/철회/조회 (5개 함수)
-├── announcements.ts    # 공지사항 조회 (페이지네이션, 고정글 우선)
-├── catalog.ts          # 카탈로그 조회 (직무군, 스킬 검색)
-└── jd-queries.ts       # 채용공고 조회 + 페이지네이션
+```text
+app/
+├── layout.tsx
+├── page.tsx
+├── error.tsx
+├── not-found.tsx
+├── jobs/
+│   ├── page.tsx
+│   ├── loading.tsx
+│   └── [id]/
+│       ├── page.tsx
+│       ├── loading.tsx
+│       └── _login-to-apply-cta.tsx
+├── announcements/
+│   ├── page.tsx
+│   ├── loading.tsx
+│   ├── error.tsx
+│   └── [id]/
+│       ├── page.tsx
+│       ├── loading.tsx
+│       └── not-found.tsx
+├── candidate/[slug]/
+│   ├── page.tsx
+│   └── profile/page.tsx
+├── (dashboard)/
+│   ├── layout.tsx
+│   ├── dashboard-sidebar.tsx
+│   └── candidate/
+│       ├── applications/
+│       │   ├── page.tsx
+│       │   └── loading.tsx
+│       └── profile/
+│           ├── page.tsx
+│           ├── loading.tsx
+│           └── edit/page.tsx
+└── api/auth/[...all]/route.ts
 ```
 
-### `lib/actions/` — 서버 액션 (얇은 어댑터)
+## 백엔드 계층 (`lib/`)
 
-`'use server'` 디렉티브. requireUser → Zod 검증 → use-case 호출.
-
-```
-lib/actions/
-├── profile.ts          # 프로필 뮤테이션/쿼리 액션 (18개 + 자격증 3개)
-├── announcements.ts    # 공지사항 쿼리 액션
-├── applications.ts     # 지원 관련 액션 (4개)
-├── catalog.ts          # 카탈로그 읽기 액션
-└── jd-queries.ts       # 채용공고 쿼리 액션
-```
-
-### `lib/validations/` — Zod 스키마
-
-서버 액션과 클라이언트 폼이 공유하는 검증 스키마.
-
-```
-lib/validations/
-├── profile.ts          # 프로필 관련 스키마 (7개 + 자격증 1개)
-├── announcement.ts     # 공지사항 필터 스키마
-├── application.ts      # 지원 스키마 (UUID 검증)
-└── job-description.ts  # 채용공고 필터 스키마
+```text
+lib/
+├── actions/          # 서버 액션 어댑터
+├── domain/           # 도메인 규칙/에러
+├── infrastructure/   # Prisma, BetterAuth, auth 유틸
+├── use-cases/        # 비즈니스 로직
+├── validations/      # Zod 스키마
+├── frontend/         # 프론트 공용 표현 유틸 (presentation)
+└── generated/prisma/ # Prisma 생성 산출물
 ```
 
-### `lib/generated/prisma/` — 자동 생성 (gitignored)
+## FSD 구조
 
-`prisma generate` 실행 시 생성. 20개 모델 타입 포함.
+### entities
 
----
-
-## 프론트엔드 — Feature-Sliced Design
-
-### `entities/` — 엔티티 표시 컴포넌트
-
-순수 표시 전용. `'use client'` 없음. Prisma 타입 미사용 (로컬 props 타입).
-
-```
+```text
 entities/
 ├── profile/ui/
-│   ├── _utils.ts           # formatDate, 레이블 맵
-│   ├── profile-header.tsx  # 이름 + aboutMe
-│   ├── career-list.tsx     # 경력 목록 (뱃지, 날짜)
-│   ├── education-list.tsx  # 학력 목록
-│   ├── language-list.tsx   # 언어 + 숙련도
-│   ├── skill-badges.tsx    # 스킬 뱃지 목록
-│   ├── url-list.tsx        # 외부 링크
-│   └── contact-info.tsx    # 연락처/이메일
+│   ├── _utils.ts
+│   ├── profile-card.tsx
+│   ├── profile-header.tsx
+│   ├── career-list.tsx
+│   ├── education-list.tsx
+│   ├── certification-list.tsx
+│   ├── language-list.tsx
+│   ├── skill-badges.tsx
+│   ├── contact-info.tsx
+│   └── url-list.tsx
 ├── job/ui/
-│   ├── _utils.ts           # 급여 포맷, 레이블 맵
-│   ├── jd-card.tsx         # 채용공고 카드
-│   └── jd-detail.tsx       # 채용공고 상세
-└── application/ui/
-    └── application-status.tsx  # 지원 상태 뱃지
+│   ├── _utils.ts
+│   ├── posting-list-item.tsx
+│   ├── posting-title.tsx
+│   ├── summary-card.tsx
+│   ├── jd-card.tsx
+│   └── jd-detail.tsx
+└── application/ui/application-status.tsx
 ```
 
-### `features/` — 기능 슬라이스
+### features
 
-각 기능은 `ui/` (컴포넌트)와 `model/` (상태/훅)로 구성.
-
-```
+```text
 features/
 ├── auth/
-│   ├── model/use-auth-modal.ts         # Zustand (모달 상태)
-│   └── ui/
-│       ├── login-modal.tsx             # 로그인 모달 (소셜 로그인 + 이메일)
-│       ├── signup-modal.tsx            # 회원가입 모달 (2단계 플로우)
-│       ├── password-input.tsx          # 비밀번호 입력 (잠금 아이콘 + 표시 토글)
-│       └── auth-redirect-handler.tsx   # ?auth=required 감지
-├── profile-edit/
-│   ├── model/use-profile-mutations.ts  # TanStack Query 뮤테이션 (16개)
-│   └── ui/
-│       ├── profile-public-form.tsx     # 기본 정보 편집
-│       ├── contact-form.tsx            # 연락처 편집
-│       ├── career-form.tsx             # 경력 추가/편집 + CareerSection
-│       ├── education-form.tsx          # 학력 편집
-│       ├── language-form.tsx           # 언어 편집
-│       ├── url-form.tsx               # URL 편집
-│       └── skill-picker.tsx            # 스킬 검색/추가/삭제
+├── apply/
 ├── job-browse/
-│   └── ui/jd-filters.tsx               # 채용공고 필터 (URL 파라미터)
-└── apply/
-    ├── model/use-apply-mutations.ts    # 지원/철회 뮤테이션
-    └── ui/apply-button.tsx             # 지원하기/철회 버튼
+│   ├── model/query-state.ts
+│   └── ui/
+└── profile-edit/
 ```
 
-### `widgets/` — 복합 위젯
+`features/job-browse/model/query-state.ts`가 jobs 목록의 `search`, `familyId`, `sort`, `page` 쿼리 상태 규칙(파싱/패치/링크 생성)의 단일 소유 지점입니다.
 
-```
+### widgets
+
+```text
 widgets/
 └── nav/ui/
-    ├── main-nav.tsx    # 전역 상단 네비게이션 (Jobs, Announcement)
-    └── user-menu.tsx   # 인증 유저 드롭다운 (Avatar + 메뉴)
+    ├── main-nav.tsx
+    └── user-menu.tsx
 ```
 
-### `components/` — shadcn/ui 프리미티브
+## `proxy.ts` 역할
 
-```
-components/
-├── providers.tsx       # QueryClientProvider 래퍼
-└── ui/                 # shadcn 컴포넌트 (14개)
-    ├── avatar.tsx, badge.tsx, button.tsx, card.tsx,
-    ├── command.tsx, dialog.tsx, dropdown-menu.tsx,
-    ├── input.tsx, label.tsx, popover.tsx, select.tsx,
-    ├── separator.tsx, skeleton.tsx, textarea.tsx
-```
+- 정적 파일 경로(확장자 포함 경로)는 인증 검사 없이 통과
+- 공개 경로(`/`, `/jobs`, `/announcements`, 공개 후보자 slug 경로, `/api/auth`)는 세션 검사 없이 통과
+- 보호 경로에서 미인증이면 `/jobs?auth=required`로 리다이렉트
 
-### `hooks/` — 공유 훅
+## 테스트 구조 (`__tests__/`)
 
-```
-hooks/
-└── use-session.ts      # auth-client의 useSession re-export
-```
-
----
-
-## Next.js 라우팅 (`app/`)
-
-```
-app/
-├── layout.tsx                          # 루트 레이아웃 (Inter 폰트, Providers, MainNav, 모달)
-├── page.tsx                            # / → /jobs 리다이렉트
-│
-├── api/auth/[...all]/route.ts          # BetterAuth API 핸들러
-│
-├── jobs/                               # 공개 (인증 불필요)
-│   ├── page.tsx                        # 채용공고 목록
-│   └── [id]/
-│       ├── page.tsx                    # 채용공고 상세
-│       └── _login-to-apply-cta.tsx     # 로그인 유도 CTA
-│
-└── (dashboard)/                        # 인증 필요 (사이드바 레이아웃)
-    ├── layout.tsx                      # 대시보드 레이아웃
-    ├── dashboard-sidebar.tsx           # 좌측 사이드바
-    └── candidate/
-        ├── profile/
-        │   ├── page.tsx               # 프로필 조회
-        │   └── edit/page.tsx          # 프로필 편집
-        ├── jobs/
-        │   ├── page.tsx               # 인증된 채용공고 목록
-        │   └── [id]/page.tsx          # 채용공고 상세 + 지원
-        └── applications/page.tsx       # 내 지원 목록
-```
-
-> **참고**: `(dashboard)`는 Next.js 라우트 그룹 — URL에 포함되지 않음.
-> 실제 URL: `/candidate/profile`, `/candidate/jobs` 등.
-> 로그인/회원가입 전용 페이지 없음 — 모달 다이얼로그로 구현.
-> 미인증 접근 → `/jobs?auth=required` 리다이렉트 → 로그인 모달 자동 오픈.
-
----
-
-## 테스트 (`__tests__/`)
-
-소스 코드 구조를 미러링. 249개 테스트.
-
-```
-__tests__/
-├── smoke.test.ts                           # Jest + SWC + 경로 별칭 스모크
-├── proxy.test.ts                           # 미들웨어 테스트 (@jest-environment node)
-├── lib/
-│   ├── domain/         (authorization, errors)
-│   ├── infrastructure/ (auth, auth-utils)
-│   ├── use-cases/      (profile, announcements, applications, catalog, jd-queries)
-│   ├── actions/        (profile, announcements, applications, catalog, jd-queries)
-│   └── validations/    (profile, announcement, application, job-description)
-├── entities/
-│   ├── profile/        (profile-header, career-list, skill-badges)
-│   └── job/            (jd-card)
-├── features/
-│   ├── auth/           (login-modal, signup-modal, use-auth-modal)
-│   ├── apply/          (apply-button)
-│   └── profile-edit/   (career-form, skill-picker)
-└── widgets/nav/        (main-nav)
-```
-
----
-
-## Prisma (`prisma/`)
-
-```
-prisma/
-├── schema.prisma       # 22 모델, 11 enum, BetterAuth 4 모델 포함
-├── seed.ts             # 카탈로그 데이터 시드 (tsx 런타임)
-├── bootstrap.sql       # 초기 DB 설정
-└── seed-data/
-    ├── job-families.json   # 5 families + 20 jobs (en/ko/vi)
-    └── skills.json         # 30 skills + aliases
-```
-
----
-
-## 설정 파일
-
-| 파일                | 용도                                      |
-| ------------------- | ----------------------------------------- |
-| `jest.config.js`    | next/jest 기반, SWC 변환, `@/*` 경로 별칭 |
-| `tsconfig.json`     | strict 모드, `@/*` 별칭                   |
-| `next.config.ts`    | (현재 빈 설정)                            |
-| `eslint.config.mjs` | ESLint 9 flat config                      |
-| `components.json`   | shadcn/ui new-york 스타일                 |
-| `prisma.config.ts`  | DIRECT_URL 우선 사용 (마이그레이션)       |
-| `proxy.ts`          | 인증 미들웨어 (주의: middleware.ts 아님)  |
+- 소스 구조를 미러링해서 `app/`, `lib/`, `entities/`, `features/`, `widgets/` 단위로 유지
+- UI 렌더링 테스트 + use-case/action 단위 테스트 + proxy/node 환경 테스트를 함께 사용

--- a/docs/implementation-plan-p5.md
+++ b/docs/implementation-plan-p5.md
@@ -357,15 +357,13 @@ P24 (Polish, E2E deferred) depends on all
 - Added announcement detail tests for `NOT_FOUND` mapping and non-404 error propagation.
 - Added route loading UI tests for all newly added `loading.tsx` files.
 
-#### Prompt 24 results (re-scoped)
+#### Prompt 24 results
 
 - E2E work is intentionally deferred and excluded from this prompt.
 - Existing Jest suite: `65 suite`, `440 tests` passed.
 - `pnpm lint` passed.
-- `pnpm exec tsc --noEmit` passed.
-- `pnpm build` is blocked in this environment by external Google Fonts fetch failures (`Inter`, `Geist Mono`), not by app code changes.
-
----
+- `pnpm tsc --noEmit` passed.
+- `pnpm build`는 `BETTER_AUTH_SECRET` 미설정 시 실패하며, 값 설정 시 통과한다.
 
 ## Deferred (Post-P24)
 
@@ -389,4 +387,4 @@ P24 (Polish, E2E deferred) depends on all
 | 21  | Jobs route merge + list/detail UI redesign                                                | Large        | P20           | ✅     |
 | 22  | Profile view/edit with all new fields + certification section                             | Large        | P18, P20      | ✅     |
 | 23  | Announcements pages + candidate landing + shareable slugs                                 | Large        | P18, P20, P22 | ✅     |
-| 24  | Error handling + loading states + FSD guardrails (E2E deferred)                           | Medium       | All           | 🔶     |
+| 24  | Error handling + loading states + FSD guardrails (E2E deferred)                           | Medium       | All           | ✅     |

--- a/docs/implementation-plan-p5.md
+++ b/docs/implementation-plan-p5.md
@@ -25,7 +25,7 @@ P19 (Social Auth)       (independent)
 P20 (Design System)  ──> P21 (Jobs UI)
                       ──> P22, P23
 
-P24 (Polish + E2E) depends on all
+P24 (Polish, E2E deferred) depends on all
 ```
 
 **Execution order: 17 → 18 → 19 → 20 → 21 → 22 → 23 → 24**
@@ -326,38 +326,44 @@ P24 (Polish + E2E) depends on all
 
 ---
 
-## Prompt 24: Polish + E2E
+## Prompt 24: Polish (E2E Deferred)
 
-**Goal**: Error boundaries, loading skeletons, build verification, integration smoke test.
+**Goal**: Complete UX/system polish without introducing new E2E coverage.
 
-**Error/loading pages**:
+**Implemented scope**:
 
-- `app/error.tsx`, `app/not-found.tsx`
-- Route-specific: `app/announcements/error.tsx`, `app/announcements/[id]/not-found.tsx`
-- Loading skeletons: `loading.tsx` for profile, jobs, announcements, applications
+- Added global and route-level boundaries:
+  - `app/error.tsx`, `app/not-found.tsx`
+  - `app/announcements/error.tsx`, `app/announcements/[id]/not-found.tsx`
+- Added route loading UIs:
+  - `app/jobs/loading.tsx`, `app/jobs/[id]/loading.tsx`
+  - `app/announcements/loading.tsx`, `app/announcements/[id]/loading.tsx`
+  - `app/(dashboard)/candidate/applications/loading.tsx`, `app/(dashboard)/candidate/profile/loading.tsx`
+- Updated announcement error contract/action handling:
+  - Domain errors now return `{ error, errorCode }`
+  - announcement detail page maps `errorCode === 'NOT_FOUND'` to `notFound()`
+  - non-404 errors are thrown to the error boundary path
+- Introduced shared presentation module: `lib/frontend/presentation.ts`
+  - moved shared formatters/label maps (`formatDate`, `formatSalary`, employment/work/proficiency/graduation/experience/education/apply labels)
+  - replaced prior `_utils` cross-slice imports
+- Added FSD guardrails in `eslint.config.mjs` using `no-restricted-imports` for:
+  - `@/entities/profile/ui/_utils`
+  - `@/entities/job/ui/_utils`
+- Reconciled structure docs: `docs/folder-structure.md`
 
-**E2E smoke test** (`__tests__/e2e/smoke.test.ts`):
+**Validation and regression updates**:
 
-- Candidate flow: profile CRUD (with new fields) → job browse (with search) → apply → view applications
-- Announcement flow: list (pinned ordering) → detail
-- Profile slug flow: public profile by slug
-- Authorization checks
+- Updated announcement action tests for `errorCode` behavior.
+- Added announcement detail tests for `NOT_FOUND` mapping and non-404 error propagation.
+- Added route loading UI tests for all newly added `loading.tsx` files.
 
-**Build verification**: `pnpm build` + `pnpm lint` + `tsc --noEmit` all clean.
+#### Prompt 24 results (re-scoped)
 
-**Frontend architecture polish (FSD alignment):**
-
-- Remove cross-entity coupling by moving shared UI labels/formatters out of entity-internal utils and into a shared frontend module, then update imports in `entities/job`, `entities/application`, `features/profile-edit`, and dashboard pages.
-- Centralize jobs query-state handling in `features/job-browse/model` (single parse/build policy for `search`, `familyId`, `sort`, `page`) and reuse it across search form, category tabs, sort control, and pagination.
-- Add lint-based layer guardrails (e.g., `no-restricted-imports`) to enforce FSD dependency direction and prevent future cross-layer leaks.
-- Reconcile architecture docs (`docs/folder-structure.md`) with the actual current structure and ownership boundaries.
-
-**Polish acceptance criteria (FSD):**
-
-- No imports from `entities/profile/ui/_utils` outside the profile entity slice.
-- Jobs browse controls preserve query state consistently under one shared policy.
-- ESLint catches prohibited cross-layer imports in CI.
-- Folder-structure documentation matches real code paths and slice responsibilities.
+- E2E work is intentionally deferred and excluded from this prompt.
+- Existing Jest suite: `65 suite`, `440 tests` passed.
+- `pnpm lint` passed.
+- `pnpm exec tsc --noEmit` passed.
+- `pnpm build` is blocked in this environment by external Google Fonts fetch failures (`Inter`, `Geist Mono`), not by app code changes.
 
 ---
 
@@ -383,4 +389,4 @@ P24 (Polish + E2E) depends on all
 | 21  | Jobs route merge + list/detail UI redesign                                                | Large        | P20           | ✅     |
 | 22  | Profile view/edit with all new fields + certification section                             | Large        | P18, P20      | ✅     |
 | 23  | Announcements pages + candidate landing + shareable slugs                                 | Large        | P18, P20, P22 | ✅     |
-| 24  | Error handling + loading states + E2E smoke test                                          | Medium       | All           | ⬜     |
+| 24  | Error handling + loading states + FSD guardrails (E2E deferred)                           | Medium       | All           | 🔶     |

--- a/entities/application/ui/application-status.tsx
+++ b/entities/application/ui/application-status.tsx
@@ -1,4 +1,4 @@
-import { APPLY_STATUS_LABELS } from '@/entities/job/ui/_utils';
+import { APPLY_STATUS_LABELS } from '@/lib/frontend/presentation';
 
 const STATUS_CLASSES: Record<string, string> = {
   applied: 'bg-blue-100 text-blue-800',

--- a/entities/job/ui/_utils.ts
+++ b/entities/job/ui/_utils.ts
@@ -1,35 +1,5 @@
-export const WORK_ARRANGEMENT_LABELS: Record<string, string> = {
-  onsite: '오피스',
-  hybrid: '하이브리드',
-  remote: '원격',
-};
-
-export const APPLY_STATUS_LABELS: Record<string, string> = {
-  applied: '지원완료',
-  accepted: '합격',
-  rejected: '불합격',
-  withdrawn: '취소',
-};
-
-const PERIOD_LABELS: Record<string, string> = {
-  year: '년',
-  month: '월',
-  hour: '시',
-};
-
-export function formatSalary(
-  min: number | null,
-  max: number | null,
-  currency: string,
-  period: string,
-  isNegotiable: boolean
-): string {
-  if (isNegotiable) return '협의';
-  if (!min && !max) return '비공개';
-  const fmt = (n: number) =>
-    currency === 'VND' && n >= 1_000_000
-      ? `${Math.round(n / 1_000_000)}M`
-      : n.toLocaleString();
-  const parts = [min && fmt(min), max && fmt(max)].filter(Boolean);
-  return `${parts.join(' - ')} ${currency}/${PERIOD_LABELS[period] ?? period}`;
-}
+export {
+  WORK_ARRANGEMENT_LABELS,
+  APPLY_STATUS_LABELS,
+  formatSalary,
+} from '@/lib/frontend/presentation';

--- a/entities/job/ui/jd-card.tsx
+++ b/entities/job/ui/jd-card.tsx
@@ -3,11 +3,9 @@ import { Card, CardContent } from '@/components/ui/card';
 import {
   EMPLOYMENT_TYPE_LABELS,
   formatDate,
-} from '@/entities/profile/ui/_utils';
-import {
   WORK_ARRANGEMENT_LABELS,
   formatSalary,
-} from '@/entities/job/ui/_utils';
+} from '@/lib/frontend/presentation';
 
 type Props = {
   id: string;

--- a/entities/job/ui/jd-detail.tsx
+++ b/entities/job/ui/jd-detail.tsx
@@ -1,9 +1,9 @@
 import ReactMarkdown from 'react-markdown';
-import { EMPLOYMENT_TYPE_LABELS } from '@/entities/profile/ui/_utils';
 import {
+  EMPLOYMENT_TYPE_LABELS,
   WORK_ARRANGEMENT_LABELS,
   formatSalary,
-} from '@/entities/job/ui/_utils';
+} from '@/lib/frontend/presentation';
 
 type Props = {
   title: string;

--- a/entities/job/ui/posting-list-item.tsx
+++ b/entities/job/ui/posting-list-item.tsx
@@ -5,8 +5,8 @@ import { Icon } from '@/components/ui/icon';
 import {
   EMPLOYMENT_TYPE_LABELS,
   formatDate,
-} from '@/entities/profile/ui/_utils';
-import { WORK_ARRANGEMENT_LABELS } from '@/entities/job/ui/_utils';
+  WORK_ARRANGEMENT_LABELS,
+} from '@/lib/frontend/presentation';
 
 type Props = {
   id: string;

--- a/entities/job/ui/posting-title.tsx
+++ b/entities/job/ui/posting-title.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@/components/ui/icon';
 import { PostStatus } from '@/components/ui/post-status';
-import { formatDate } from '@/entities/profile/ui/_utils';
+import { formatDate } from '@/lib/frontend/presentation';
 
 type Props = {
   title: string;

--- a/entities/job/ui/summary-card.tsx
+++ b/entities/job/ui/summary-card.tsx
@@ -1,8 +1,10 @@
 import { Icon } from '@/components/ui/icon';
 import { Chip } from '@/components/ui/chip';
 import { Button } from '@/components/ui/button';
-import { EMPLOYMENT_TYPE_LABELS } from '@/entities/profile/ui/_utils';
-import { WORK_ARRANGEMENT_LABELS } from '@/entities/job/ui/_utils';
+import {
+  EMPLOYMENT_TYPE_LABELS,
+  WORK_ARRANGEMENT_LABELS,
+} from '@/lib/frontend/presentation';
 
 type Props = {
   jobDisplayNameEn: string;

--- a/entities/profile/ui/_utils.ts
+++ b/entities/profile/ui/_utils.ts
@@ -1,45 +1,8 @@
-export function formatDate(date: Date): string {
-  return `${date.getUTCFullYear()}.${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
-}
-
-export const EMPLOYMENT_TYPE_LABELS: Record<string, string> = {
-  full_time: '정규직',
-  part_time: '파트타임',
-  intern: '인턴',
-  freelance: '프리랜서',
-};
-
-export const PROFICIENCY_LABELS: Record<string, string> = {
-  native: '원어민',
-  fluent: '유창',
-  professional: '업무 가능',
-  basic: '기초',
-};
-
-export const GRADUATION_STATUS_LABELS: Record<string, string> = {
-  ENROLLED: '재학 중',
-  ON_LEAVE: '휴학',
-  GRADUATED: '졸업',
-  EXPECTED: '졸업 예정',
-  WITHDRAWN: '중퇴',
-};
-
-export const EXPERIENCE_LEVEL_LABELS: Record<string, string> = {
-  ENTRY: 'Entry',
-  JUNIOR: 'Junior',
-  MID: 'Mid',
-  SENIOR: 'Senior',
-  LEAD: 'Lead',
-};
-
-export const EDUCATION_TYPE_LABELS: Record<string, string> = {
-  vet_elementary: '직업 초급',
-  vet_intermediate: '직업 중급',
-  vet_college: '직업 대학',
-  higher_bachelor: '학사',
-  higher_master: '석사',
-  higher_doctorate: '박사',
-  continuing_education: '평생교육',
-  international_program: '국제 프로그램',
-  other: '기타',
-};
+export {
+  formatDate,
+  EMPLOYMENT_TYPE_LABELS,
+  PROFICIENCY_LABELS,
+  GRADUATION_STATUS_LABELS,
+  EXPERIENCE_LEVEL_LABELS,
+  EDUCATION_TYPE_LABELS,
+} from '@/lib/frontend/presentation';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,28 @@ import nextTs from 'eslint-config-next/typescript';
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    files: ['**/*.{js,mjs,cjs,ts,tsx,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@/entities/profile/ui/_utils',
+              message:
+                '공유 프레젠테이션 유틸은 "@/lib/frontend/presentation"에서 가져오세요.',
+            },
+            {
+              name: '@/entities/job/ui/_utils',
+              message:
+                '공유 프레젠테이션 유틸은 "@/lib/frontend/presentation"에서 가져오세요.',
+            },
+          ],
+        },
+      ],
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/features/profile-edit/ui/career-form.tsx
+++ b/features/profile-edit/ui/career-form.tsx
@@ -27,7 +27,7 @@ import { FormDropdown } from '@/components/ui/form-dropdown';
 import {
   EMPLOYMENT_TYPE_LABELS,
   EXPERIENCE_LEVEL_LABELS,
-} from '@/entities/profile/ui/_utils';
+} from '@/lib/frontend/presentation';
 import {
   useAddCareer,
   useUpdateCareer,

--- a/features/profile-edit/ui/education-form.tsx
+++ b/features/profile-edit/ui/education-form.tsx
@@ -23,7 +23,7 @@ import {
 import {
   EDUCATION_TYPE_LABELS,
   GRADUATION_STATUS_LABELS,
-} from '@/entities/profile/ui/_utils';
+} from '@/lib/frontend/presentation';
 import {
   useAddEducation,
   useUpdateEducation,

--- a/features/profile-edit/ui/language-form.tsx
+++ b/features/profile-edit/ui/language-form.tsx
@@ -22,7 +22,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { PROFICIENCY_LABELS } from '@/entities/profile/ui/_utils';
+import { PROFICIENCY_LABELS } from '@/lib/frontend/presentation';
 import {
   useAddLanguage,
   useUpdateLanguage,

--- a/features/profile-edit/ui/profile-edit-page-client.tsx
+++ b/features/profile-edit/ui/profile-edit-page-client.tsx
@@ -28,7 +28,7 @@ import {
   EXPERIENCE_LEVEL_LABELS,
   GRADUATION_STATUS_LABELS,
   PROFICIENCY_LABELS,
-} from '@/entities/profile/ui/_utils';
+} from '@/lib/frontend/presentation';
 import {
   useAddCareer,
   useAddCertification,

--- a/lib/actions/announcements.ts
+++ b/lib/actions/announcements.ts
@@ -9,10 +9,14 @@ import {
   getAnnouncementNeighbors as ucGetAnnouncementNeighbors,
 } from '@/lib/use-cases/announcements';
 
-type QueryResult<T> = { success: true; data: T } | { error: string };
+type QueryResult<T> =
+  | { success: true; data: T }
+  | { error: string; errorCode?: string };
 
-function handleError(e: unknown): { error: string } {
-  if (e instanceof DomainError) return { error: e.message };
+function handleError(e: unknown): { error: string; errorCode?: string } {
+  if (e instanceof DomainError) {
+    return { error: e.message, errorCode: e.code };
+  }
   if (e instanceof ZodError) return { error: '필터 값이 유효하지 않습니다' };
   throw e;
 }

--- a/lib/frontend/presentation.ts
+++ b/lib/frontend/presentation.ts
@@ -1,0 +1,81 @@
+export function formatDate(date: Date): string {
+  return `${date.getUTCFullYear()}.${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+export const EMPLOYMENT_TYPE_LABELS: Record<string, string> = {
+  full_time: '정규직',
+  part_time: '파트타임',
+  intern: '인턴',
+  freelance: '프리랜서',
+};
+
+export const PROFICIENCY_LABELS: Record<string, string> = {
+  native: '원어민',
+  fluent: '유창',
+  professional: '업무 가능',
+  basic: '기초',
+};
+
+export const GRADUATION_STATUS_LABELS: Record<string, string> = {
+  ENROLLED: '재학 중',
+  ON_LEAVE: '휴학',
+  GRADUATED: '졸업',
+  EXPECTED: '졸업 예정',
+  WITHDRAWN: '중퇴',
+};
+
+export const EXPERIENCE_LEVEL_LABELS: Record<string, string> = {
+  ENTRY: 'Entry',
+  JUNIOR: 'Junior',
+  MID: 'Mid',
+  SENIOR: 'Senior',
+  LEAD: 'Lead',
+};
+
+export const EDUCATION_TYPE_LABELS: Record<string, string> = {
+  vet_elementary: '직업 초급',
+  vet_intermediate: '직업 중급',
+  vet_college: '직업 대학',
+  higher_bachelor: '학사',
+  higher_master: '석사',
+  higher_doctorate: '박사',
+  continuing_education: '평생교육',
+  international_program: '국제 프로그램',
+  other: '기타',
+};
+
+export const WORK_ARRANGEMENT_LABELS: Record<string, string> = {
+  onsite: '오피스',
+  hybrid: '하이브리드',
+  remote: '원격',
+};
+
+export const APPLY_STATUS_LABELS: Record<string, string> = {
+  applied: '지원완료',
+  accepted: '합격',
+  rejected: '불합격',
+  withdrawn: '취소',
+};
+
+const PERIOD_LABELS: Record<string, string> = {
+  year: '년',
+  month: '월',
+  hour: '시',
+};
+
+export function formatSalary(
+  min: number | null,
+  max: number | null,
+  currency: string,
+  period: string,
+  isNegotiable: boolean
+): string {
+  if (isNegotiable) return '협의';
+  if (!min && !max) return '비공개';
+  const fmt = (n: number) =>
+    currency === 'VND' && n >= 1_000_000
+      ? `${Math.round(n / 1_000_000)}M`
+      : n.toLocaleString();
+  const parts = [min && fmt(min), max && fmt(max)].filter(Boolean);
+  return `${parts.join(' - ')} ${currency}/${PERIOD_LABELS[period] ?? period}`;
+}

--- a/todo.md
+++ b/todo.md
@@ -51,16 +51,16 @@
 
 > 상세 계획: [docs/implementation-plan-p5.md](docs/implementation-plan-p5.md)
 
-| #   | 프롬프트                          | 범위                                             | 의존성        | 상태 |
-| --- | --------------------------------- | ------------------------------------------------ | ------------- | ---- |
-| 17  | 스키마 마이그레이션               | isGraduated→graduationStatus, 새 필드/모델 추가  | —             | ✅   |
-| 18  | 자격증 CRUD + 공지사항 백엔드     | 새 Zod 스키마, use-case, action                  | P17           | ✅   |
-| 19  | 소셜 로그인 + 인증 모달 재설계    | Google/Facebook OAuth, 2단계 회원가입            | —             | ✅   |
-| 20  | 디자인 시스템 컴포넌트            | Icon, InputWithIcon, StatusIndicator, Pagination | —             | ✅   |
-| 21  | 채용공고 라우트 통합 + UI 재설계  | `/candidate/jobs` → `/jobs` 통합, 검색/탭/정렬   | P20           | ✅   |
-| 22  | 프로필 조회/편집 재설계           | 새 필드 반영, 자격증 섹션, 섹션 순서 변경        | P18, P20      | ✅   |
-| 23  | 공지사항 + 후보자 랜딩 + 공유 URL | 공지 목록/상세, 프로필 슬러그                    | P18, P20, P22 | ✅   |
-| 24  | 에러 처리 + 로딩 + E2E 테스트     | error.tsx, loading.tsx, 스모크 테스트            | 전체          | ⬜   |
+| #   | 프롬프트                               | 범위                                               | 의존성        | 상태 |
+| --- | -------------------------------------- | -------------------------------------------------- | ------------- | ---- |
+| 17  | 스키마 마이그레이션                    | isGraduated→graduationStatus, 새 필드/모델 추가    | —             | ✅   |
+| 18  | 자격증 CRUD + 공지사항 백엔드          | 새 Zod 스키마, use-case, action                    | P17           | ✅   |
+| 19  | 소셜 로그인 + 인증 모달 재설계         | Google/Facebook OAuth, 2단계 회원가입              | —             | ✅   |
+| 20  | 디자인 시스템 컴포넌트                 | Icon, InputWithIcon, StatusIndicator, Pagination   | —             | ✅   |
+| 21  | 채용공고 라우트 통합 + UI 재설계       | `/candidate/jobs` → `/jobs` 통합, 검색/탭/정렬     | P20           | ✅   |
+| 22  | 프로필 조회/편집 재설계                | 새 필드 반영, 자격증 섹션, 섹션 순서 변경          | P18, P20      | ✅   |
+| 23  | 공지사항 + 후보자 랜딩 + 공유 URL      | 공지 목록/상세, 프로필 슬러그                      | P18, P20, P22 | ✅   |
+| 24  | 에러/로딩 UX + FSD 가드레일 (E2E 제외) | error.tsx, not-found.tsx, loading.tsx, import 가드 | 전체          | 🔶   |
 
 ---
 
@@ -79,6 +79,8 @@
 
 ## 현재 상태
 
-- **테스트**: 431개 통과 (64 suite)
-- **타입 체크**: `tsc --noEmit` 클린
-- **브랜치**: `feat/prompt23-active-component-alignment`
+- **테스트**: 440개 통과 (65 suite)
+- **타입 체크**: `pnpm exec tsc --noEmit` 클린
+- **린트**: `pnpm lint` 클린
+- **빌드**: `pnpm build`는 Google Fonts 네트워크 fetch 제한으로 실패 (Inter/Geist Mono)
+- **브랜치**: `feat/prompt24-polish-e2e`

--- a/todo.md
+++ b/todo.md
@@ -60,7 +60,7 @@
 | 21  | 채용공고 라우트 통합 + UI 재설계       | `/candidate/jobs` → `/jobs` 통합, 검색/탭/정렬     | P20           | ✅   |
 | 22  | 프로필 조회/편집 재설계                | 새 필드 반영, 자격증 섹션, 섹션 순서 변경          | P18, P20      | ✅   |
 | 23  | 공지사항 + 후보자 랜딩 + 공유 URL      | 공지 목록/상세, 프로필 슬러그                      | P18, P20, P22 | ✅   |
-| 24  | 에러/로딩 UX + FSD 가드레일 (E2E 제외) | error.tsx, not-found.tsx, loading.tsx, import 가드 | 전체          | 🔶   |
+| 24  | 에러/로딩 UX + FSD 가드레일 (E2E 제외) | error.tsx, not-found.tsx, loading.tsx, import 가드 | 전체          | ✅   |
 
 ---
 
@@ -80,7 +80,7 @@
 ## 현재 상태
 
 - **테스트**: 440개 통과 (65 suite)
-- **타입 체크**: `pnpm exec tsc --noEmit` 클린
+- **타입 체크**: `pnpm tsc --noEmit` 클린
 - **린트**: `pnpm lint` 클린
-- **빌드**: `pnpm build`는 Google Fonts 네트워크 fetch 제한으로 실패 (Inter/Geist Mono)
+- **빌드**: `BETTER_AUTH_SECRET` 미설정 시 실패, 설정 시 통과
 - **브랜치**: `feat/prompt24-polish-e2e`


### PR DESCRIPTION
## 요약
Prompt 24 범위에서 사용자 경험 폴리시 작업을 진행했습니다.
주요 목표는 라우트 단위 로딩/에러/노트파운드 처리 강화, 공지 상세 404 매핑 정확도 개선, 그리고 프레젠테이션 유틸 정리를 통한 중복 제거입니다.

## 변경 사항

### 1) 공지 상세 에러 처리 개선
- `lib/actions/announcements.ts`
  - `DomainError` 처리 시 `errorCode`를 함께 반환하도록 확장했습니다.
- `app/announcements/[id]/page.tsx`
  - `NOT_FOUND` 에러 코드를 `notFound()`로 매핑하도록 반영했습니다.
  - 공지 상세 페이지에서 404 라우팅 동작을 명확히 했습니다.

### 2) 라우트 로딩/에러/노트파운드 UI 추가
- 신규 로딩 페이지
  - `app/jobs/loading.tsx`
  - `app/jobs/[id]/loading.tsx`
  - `app/announcements/loading.tsx`
  - `app/announcements/[id]/loading.tsx`
  - `app/(dashboard)/candidate/profile/loading.tsx`
  - `app/(dashboard)/candidate/applications/loading.tsx`
- 신규 에러/노트파운드 페이지
  - `app/error.tsx`
  - `app/not-found.tsx`
  - `app/announcements/error.tsx`
  - `app/announcements/[id]/not-found.tsx`

### 3) 프레젠테이션 유틸 통합 및 import 경로 정리
- `lib/frontend/presentation.ts`에 공통 포맷/레이블 유틸을 통합했습니다.
- 중복 유틸 참조를 제거하고 엔티티 계층에서 공통 유틸 import를 사용하도록 정리했습니다.
  - 예: `entities/job/ui/*`, `entities/profile/ui/*`, `features/profile-edit/ui/*` 일부 파일

### 4) ESLint import 가드 추가
- `eslint.config.mjs`
  - 레이어 규칙 보강 및 금지 import 경로를 명시해 아키텍처 경계를 강화했습니다.

### 5) 문서/진행 현황 동기화
- `docs/implementation-plan-p5.md` 결과 섹션 업데이트
- `docs/folder-structure.md` 및 `todo.md` 최신 상태 반영

## 변경 규모
- 총 32개 파일 변경
- 689 insertions / 408 deletions

## 테스트
아래 변경 영향 테스트를 실행해 모두 통과했습니다.

- `pnpm test -- __tests__/app/announcement-detail-page.test.tsx __tests__/app/loading-pages.test.tsx __tests__/lib/actions/announcements.test.ts`

결과:
- Test Suites: 3 passed
- Tests: 16 passed

## 리뷰 포인트
- 공지 상세의 `errorCode=NOT_FOUND` 처리 경로가 의도대로 404 페이지로 연결되는지
- 신규 loading/error/not-found 페이지의 톤/스타일 일관성
- `lib/frontend/presentation.ts` 통합 이후 각 UI 컴포넌트의 표시값 회귀 여부
- ESLint import 가드가 현재/향후 개발 흐름에 과도한 제약을 주지 않는지
