### PR TITLE
후보자 내 프로필 페이지 구현 불일치 보정 (item #1)

### DIFF
--- a/__tests__/app/candidate-profile-page.test.tsx
+++ b/__tests__/app/candidate-profile-page.test.tsx
@@ -1,0 +1,156 @@
+import { screen } from '@testing-library/react';
+import CandidateProfilePage from '@/app/(dashboard)/candidate/profile/page';
+import { getMyProfile } from '@/lib/actions/profile';
+import { requireUser } from '@/lib/infrastructure/auth-utils';
+import { renderWithI18n } from '@/__tests__/test-utils/render-with-i18n';
+
+jest.mock('@/lib/actions/profile', () => ({
+  getMyProfile: jest.fn(),
+}));
+jest.mock('@/lib/infrastructure/auth-utils', () => ({
+  requireUser: jest.fn(),
+  getCurrentUser: jest.fn(),
+  requireRole: jest.fn(),
+}));
+jest.mock('@/lib/i18n/server', () => {
+  const { enMessages } = jest.requireActual('@/lib/i18n/messages/en');
+  return {
+    getServerI18n: jest.fn(async () => ({
+      locale: 'en',
+      messages: enMessages,
+      t: (key: string) => enMessages[key] ?? key,
+    })),
+  };
+});
+
+const mockGetMyProfile = getMyProfile as unknown as jest.Mock;
+const mockRequireUser = requireUser as unknown as jest.Mock;
+
+const profileData = {
+  id: 'user-1',
+  authUser: { email: 'lion@vridge.net' },
+  profilePublic: {
+    firstName: 'Lion',
+    lastName: 'Park',
+    dateOfBirth: new Date('2000-02-10T00:00:00.000Z'),
+    location: 'Ho Chi Minh City',
+    headline: 'Product Designer',
+    aboutMe: 'Designing intuitive products',
+    isOpenToWork: true,
+    profileImageUrl: null,
+    isPublic: true,
+    publicSlug: 'lion-park',
+  },
+  profilePrivate: {
+    phoneNumber: '+84 1234 5678',
+  },
+  careers: [
+    {
+      id: 'career-1',
+      companyName: 'Flowbit',
+      positionTitle: 'UI Designer',
+      employmentType: 'full_time',
+      startDate: new Date('2022-01-01T00:00:00.000Z'),
+      endDate: null,
+      description: 'Led design system.',
+      experienceLevel: 'SENIOR',
+      sortOrder: 0,
+      job: { displayNameEn: 'Designer' },
+    },
+  ],
+  educations: [
+    {
+      id: 'edu-1',
+      institutionName: 'Hanoi University',
+      educationType: 'higher_bachelor',
+      field: 'Industrial Design',
+      graduationStatus: 'GRADUATED',
+      startDate: new Date('2020-09-01T00:00:00.000Z'),
+      endDate: new Date('2024-02-01T00:00:00.000Z'),
+      sortOrder: 0,
+    },
+  ],
+  languages: [
+    {
+      id: 'lang-1',
+      language: 'English',
+      proficiency: 'professional',
+      testName: 'TOEFL',
+      testScore: '100',
+      sortOrder: 0,
+    },
+  ],
+  urls: [
+    {
+      id: 'url-1',
+      label: 'Portfolio',
+      url: 'https://example.com',
+      sortOrder: 0,
+    },
+  ],
+  profileSkills: [{ skill: { displayNameEn: 'Figma' } }],
+  certifications: [
+    {
+      id: 'cert-1',
+      name: 'UX Design Excellence Award',
+      date: new Date('2023-01-01T00:00:00.000Z'),
+      description: 'Awarded for UX outcomes.',
+      institutionName: 'Fintech Asia Conference',
+      sortOrder: 0,
+    },
+  ],
+};
+
+describe('CandidateProfilePage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireUser.mockResolvedValue({
+      userId: 'candidate-1',
+      role: 'candidate',
+      email: 'lion@vridge.net',
+      orgId: null,
+    });
+  });
+
+  it('내 프로필 페이지를 렌더링하고 Edit Profile CTA를 표시한다', async () => {
+    mockGetMyProfile.mockResolvedValue({
+      success: true,
+      data: profileData,
+    });
+
+    const ui = await CandidateProfilePage();
+    renderWithI18n(ui);
+
+    expect(screen.getByText('Basic Profile')).toBeInTheDocument();
+    expect(screen.getByText('Education')).toBeInTheDocument();
+    expect(screen.getByText('Skills')).toBeInTheDocument();
+    expect(screen.getByText('Experience')).toBeInTheDocument();
+    expect(screen.getByText('Certification')).toBeInTheDocument();
+    expect(screen.getByText('Languages')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Portfolio' })
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Lion Park')).toBeInTheDocument();
+    expect(screen.getByText('lion@vridge.net')).toBeInTheDocument();
+    expect(screen.getByText('+84 1234 5678')).toBeInTheDocument();
+
+    expect(screen.getByRole('link', { name: 'Edit Profile' })).toHaveAttribute(
+      'href',
+      '/candidate/profile/edit'
+    );
+  });
+
+  it('액션 에러가 발생하면 에러 메시지를 렌더링한다', async () => {
+    mockGetMyProfile.mockResolvedValue({
+      errorCode: 'NOT_FOUND',
+      errorKey: 'error.notFound',
+      errorMessage: '프로필을 찾을 수 없습니다.',
+    });
+
+    const ui = await CandidateProfilePage();
+    renderWithI18n(ui);
+
+    expect(screen.getByText('프로필을 찾을 수 없습니다.')).toBeInTheDocument();
+  });
+});

--- a/app/(dashboard)/candidate/profile/page.tsx
+++ b/app/(dashboard)/candidate/profile/page.tsx
@@ -1,4 +1,13 @@
-import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { SectionTitle } from '@/components/ui/section-title';
+import { ProfileCard } from '@/entities/profile/ui/profile-card';
+import { EducationList } from '@/entities/profile/ui/education-list';
+import { SkillBadges } from '@/entities/profile/ui/skill-badges';
+import { CareerList } from '@/entities/profile/ui/career-list';
+import { CertificationList } from '@/entities/profile/ui/certification-list';
+import { LanguageList } from '@/entities/profile/ui/language-list';
+import { UrlList } from '@/entities/profile/ui/url-list';
 import { getMyProfile } from '@/lib/actions/profile';
 import { requireUser } from '@/lib/infrastructure/auth-utils';
 import { getServerI18n } from '@/lib/i18n/server';
@@ -6,19 +15,99 @@ import { getActionErrorMessage } from '@/lib/i18n/action-error';
 
 export default async function CandidateProfilePage() {
   const { t } = await getServerI18n();
-  await requireUser();
+  const user = await requireUser();
   const result = await getMyProfile();
 
   if ('errorCode' in result) {
     return (
-      <p className="text-destructive">{getActionErrorMessage(result, t)}</p>
+      <p className="p-6 text-destructive">{getActionErrorMessage(result, t)}</p>
     );
   }
 
-  const slug = result.data.profilePublic?.publicSlug;
-  if (!slug) {
-    return <p className="text-destructive">{t('profile.slugMissing')}</p>;
-  }
+  const {
+    profilePublic,
+    profilePrivate,
+    careers,
+    educations,
+    languages,
+    urls,
+    profileSkills,
+    certifications,
+  } = result.data;
 
-  redirect(`/candidate/${slug}/profile`);
+  return (
+    <>
+      <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-6 pb-24">
+        <section className="rounded-[20px] bg-white px-10 py-5">
+          <SectionTitle title={t('profile.basicProfile')} />
+          <div className="mt-6">
+            <ProfileCard
+              firstName={profilePublic?.firstName ?? ''}
+              lastName={profilePublic?.lastName ?? ''}
+              dateOfBirth={profilePublic?.dateOfBirth ?? undefined}
+              phone={profilePrivate?.phoneNumber}
+              email={user.email}
+              location={profilePublic?.location}
+              headline={profilePublic?.headline}
+              aboutMe={profilePublic?.aboutMe}
+              isOpenToWork={profilePublic?.isOpenToWork ?? false}
+              profileImageUrl={profilePublic?.profileImageUrl}
+            />
+          </div>
+        </section>
+
+        <section className="rounded-[20px] bg-white px-10 py-5">
+          <SectionTitle title={t('profile.education')} />
+          <div className="mt-6">
+            <EducationList educations={educations} />
+          </div>
+        </section>
+
+        <section className="rounded-[20px] bg-white px-10 py-5">
+          <SectionTitle title={t('profile.skills')} />
+          <div className="mt-6">
+            <SkillBadges skills={profileSkills} />
+          </div>
+        </section>
+
+        <section className="rounded-[20px] bg-white px-10 py-5">
+          <SectionTitle title={t('profile.experience')} />
+          <div className="mt-6">
+            <CareerList careers={careers} />
+          </div>
+        </section>
+
+        <section className="rounded-[20px] bg-white px-10 py-5">
+          <SectionTitle title={t('profile.certification')} />
+          <div className="mt-6">
+            <CertificationList certifications={certifications} />
+          </div>
+        </section>
+
+        <section className="rounded-[20px] bg-white px-10 py-5">
+          <SectionTitle title={t('profile.languages')} />
+          <div className="mt-6">
+            <LanguageList languages={languages} />
+          </div>
+        </section>
+
+        <section className="rounded-[20px] bg-white px-10 py-5">
+          <SectionTitle title={t('profile.portfolio')} />
+          <div className="mt-6">
+            <UrlList urls={urls} />
+          </div>
+        </section>
+      </div>
+
+      <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-white/90 px-6 py-3 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-[1200px] items-center justify-end">
+          <Button asChild variant="brand" size="brand-lg">
+            <Link href="/candidate/profile/edit">
+              {t('profile.actions.editProfile')}
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </>
+  );
 }

--- a/components/ui/post-status.tsx
+++ b/components/ui/post-status.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Icon } from './icon';
 import { useI18n } from '@/lib/i18n/client';
 

--- a/docs/folder-structure.md
+++ b/docs/folder-structure.md
@@ -70,6 +70,8 @@ app/
 └── api/auth/[...all]/route.ts
 ```
 
+- `/candidate/profile`는 대시보드 내 "내 프로필" 화면을 직접 렌더링하며, 하단 CTA로 `/candidate/profile/edit`에 연결됩니다.
+
 ## 백엔드 계층 (`lib/`)
 
 ```text
@@ -182,6 +184,7 @@ stories/
 - 소스 구조를 미러링하여 `app/`, `lib/`, `entities/`, `features/`, `widgets/` 단위로 유지
 - UI 렌더링 테스트 + use-case/action 단위 테스트 + `proxy.ts` node 환경 테스트
 - i18n 클라이언트 컴포넌트는 `__tests__/test-utils/render-with-i18n.tsx`로 감싸서 렌더링
+- 내 프로필 라우트 회귀 테스트: `__tests__/app/candidate-profile-page.test.tsx`
 
 ## `proxy.ts` 역할
 

--- a/docs/project-state-requirements.md
+++ b/docs/project-state-requirements.md
@@ -81,8 +81,15 @@
 - [ ] 포트폴리오 파일 첨부(현재 URL 링크 목록)
 - [x] 언어 시험명/점수 표시
 - [x] 기본 프로필 섹션 카드 구성
-- [ ] Figma와 동일한 편집 버튼 위치/스타일
+- [x] 공개 프로필은 읽기 전용(편집 버튼 없음, 편집 진입은 `/candidate/profile`)
 - [x] 섹션 순서(Basic → Education → Skills → Experience → Certification → Languages → Portfolio)
+
+## My Profile (`/candidate/profile`)
+
+- [x] slug 페이지 리다이렉트 없이 대시보드 내 페이지 직접 렌더링
+- [x] Basic → Education → Skills → Experience → Certification → Languages → Portfolio 섹션 렌더링
+- [x] 하단 고정 `Edit Profile` CTA
+- [x] `Edit Profile` 클릭 시 `/candidate/profile/edit` 이동
 
 ## Profile Edit (`/candidate/profile/edit`)
 

--- a/docs/project-state.md
+++ b/docs/project-state.md
@@ -1,11 +1,11 @@
 # 프로젝트 상태 — vridge ATS MVP
 
-> 내부 공유 문서 (기준 브랜치: `dev`)
+> 내부 공유 문서 (기준 브랜치: `feat/item1-candidate-profile-fix`)
 
 ## 현재 스냅샷
 
-- 브랜치: `dev`
-- 테스트: `70` suite, `457` tests 통과
+- 브랜치: `feat/item1-candidate-profile-fix`
+- 테스트: `71` suite, `459` tests 통과
 - 타입 체크: `pnpm exec tsc --noEmit` 통과
 - 앱 라우팅: Next.js App Router (`app/`)
 - 인증: Better Auth + `proxy.ts` 기반 라우트 보호
@@ -30,6 +30,7 @@
 - 후보자 공개 페이지(`app/candidate/[slug]/*`)
 - 대시보드 내 내 프로필/프로필 편집/내 지원 목록
 - 전역 `error.tsx`, `not-found.tsx`, 라우트별 `loading.tsx`/`error.tsx` 반영
+- `app/(dashboard)/candidate/profile/page.tsx`는 더 이상 slug 페이지로 리다이렉트하지 않고, 내 프로필 섹션 렌더링 + 하단 `Edit Profile` CTA 제공
 
 ### i18n (Phase 6)
 
@@ -77,6 +78,8 @@
 - `/candidate/profile/edit`
 - `/candidate/applications`
 
+`/candidate/profile`은 인증 사용자 기준 대시보드형 내 프로필 화면(읽기)이며, 편집 진입은 `/candidate/profile/edit`로 연결됩니다.
+
 ### 미구현/후속 라우트 (채용담당자)
 
 - `/recruiter` 대시보드
@@ -96,6 +99,8 @@
   - i18n 의존 클라이언트 컴포넌트는 `__tests__/test-utils/render-with-i18n.tsx` 사용
 - Storybook 스토리 위치
   - 구현 컴포넌트와 분리하여 `stories/ui`에 문서 스토리를 유지
+- 클라이언트 경계
+  - `components/ui/post-status.tsx`는 `useI18n()` 사용을 위해 클라이언트 컴포넌트로 유지
 
 ## 보류/후속 과제
 

--- a/fix_needed.md
+++ b/fix_needed.md
@@ -1,0 +1,68 @@
+1.
+
+- route: app/(dashboard)/candidate/profile
+- design: https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=323-1107&m=dev
+- description: profile of the candidate
+- current state: is being redirected by proxy, edit button does not exist
+
+2.
+
+- route: app/candidate/[slug]
+- design: https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=283-2572&m=dev
+- description: public profile of the candidate
+- current state: i18n related issue
+
+3.
+
+- route: app/(dashboard)/candidate/profile/edit
+- design: https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=323-560&m=dev , https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=323-783&m=dev
+- description: edit mode of profile of the candidate
+- current state: is not linked from profile page
+
+4.
+
+- route: app/(dashboard)/candidate/jobs
+- design: https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=283-2635&m=dev
+- description: jobs applied by the candidate
+- current state: minor design mismatch
+
+5.
+
+- component: Email field, Password field
+- design: https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=386-3148&m=dev, https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=386-3149&m=dev
+- description: login / signup fields
+- current state: design mismatch and icon mismatch (hidden password should be paired with hidden.svg, current implementation has flipped icon states)
+
+6.
+
+- route: app/jobs
+- design: https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=315-15170&m=dev
+- description : jobs page
+- current state: design mismatch and feature mismatch (where is the apply button??)
+
+7.
+
+- route: app/jobs/[id]
+- design: https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=330-3286&m=dev
+- description : jobs detail
+- current state: design mismatch and feature mismatch (withdraw not needed in this page and job description share button missing.)
+
+8.
+
+- route: app/annoucnments
+- design: https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=315-15060&m=dev
+- description: announcements
+- current state: design mismatch
+
+8.
+
+- route: app/annoucnments/[id]
+- design: https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=315-15103&m=dev
+- description: announcements detail
+- current state: design mismatch
+
+9.
+
+- components : the entire sign in / sign up flow
+- design: https://www.figma.com/design/27tn2lCDeji78dNzuOICXv/Vridge-Web-Ver-0.1?node-id=285-14949&m=dev
+- current state: highly likely desing mismatch

--- a/lib/i18n/messages/en.ts
+++ b/lib/i18n/messages/en.ts
@@ -147,6 +147,7 @@ export const enMessages = {
   'profile.actions.addCertification': '+ Add certification',
   'profile.actions.addLanguage': '+ Add language',
   'profile.actions.addUrl': '+ Add link',
+  'profile.actions.editProfile': 'Edit Profile',
 
   'form.firstName': 'First Name',
   'form.lastName': 'Last Name',

--- a/lib/i18n/messages/ko.ts
+++ b/lib/i18n/messages/ko.ts
@@ -137,6 +137,7 @@ export const koMessages: Record<MessageKey, string> = {
   'profile.actions.addCertification': '+ 자격증 추가',
   'profile.actions.addLanguage': '+ 언어 추가',
   'profile.actions.addUrl': '+ 링크 추가',
+  'profile.actions.editProfile': '프로필 수정',
 
   'form.firstName': '이름',
   'form.lastName': '성',

--- a/lib/i18n/messages/vi.ts
+++ b/lib/i18n/messages/vi.ts
@@ -144,6 +144,7 @@ export const viMessages: Record<MessageKey, string> = {
   'profile.actions.addCertification': '+ Thêm chứng chỉ',
   'profile.actions.addLanguage': '+ Thêm ngôn ngữ',
   'profile.actions.addUrl': '+ Thêm liên kết',
+  'profile.actions.editProfile': 'Chỉnh sửa hồ sơ',
 
   'form.firstName': 'Tên',
   'form.lastName': 'Họ',

--- a/todo.md
+++ b/todo.md
@@ -77,6 +77,21 @@
 | --- | ----------------------------------------------- | ---- |
 | 29  | Prompt 20 Tier-1 공통 컴포넌트 Storybook 문서화 | ✅   |
 
+## Hotfix: 구현 불일치 보정 (`fix_needed.md`)
+
+| #   | 작업                                   | 상태 |
+| --- | -------------------------------------- | ---- |
+| 30  | `/candidate/profile` 렌더링/수정 CTA   | ✅   |
+| 31  | `/candidate/[slug]` i18n 이슈 정리     | ⬜   |
+| 32  | `/candidate/profile/edit` 링크/동선    | ⬜   |
+| 33  | `/candidate/applications` 디자인 보정  | ⬜   |
+| 34  | 인증 입력 필드(이메일/비밀번호) 아이콘 | ⬜   |
+| 35  | `/jobs` 디자인/기능 보정               | ⬜   |
+| 36  | `/jobs/[id]` 디자인/기능 보정          | ⬜   |
+| 37  | `/announcements` 디자인 보정           | ⬜   |
+| 38  | `/announcements/[id]` 디자인 보정      | ⬜   |
+| 39  | 로그인/회원가입 플로우 전반 보정       | ⬜   |
+
 ---
 
 ## 보류 항목 (Post-P6)
@@ -94,8 +109,8 @@
 
 ## 현재 상태
 
-- **브랜치**: `feat/prompt25-storybook-docs`
-- **테스트**: 457개 통과 (70 suite)
+- **브랜치**: `feat/item1-candidate-profile-fix`
+- **테스트**: 459개 통과 (71 suite)
 - **타입 체크**: `pnpm exec tsc --noEmit` 클린
 - **로케일 정책**: `vi` 기본, `en/ko` 지원, 쿠키 키 `vridge_locale`
 - **에러 계약**: 서버 액션은 `{ errorCode, errorKey, errorMessage? }` 형태로 표준화


### PR DESCRIPTION
## 요약
- `/candidate/profile` 라우트를 slug 리다이렉트 방식에서 대시보드 내 프로필 렌더링 방식으로 변경했습니다.
- 프로필 페이지 하단에 고정 `Edit Profile` CTA를 추가하고 `/candidate/profile/edit`로 연결했습니다.
- `useI18n()` 서버 호출 오류를 해결하기 위해 `PostStatus`를 클라이언트 컴포넌트로 명시했습니다.
- i18n 키 `profile.actions.editProfile`를 `en/ko/vi` 메시지에 추가했습니다.
- 관련 문서(`todo.md`, `docs/folder-structure.md`, `docs/project-state.md`, `docs/project-state-requirements.md`)를 최신 상태로 갱신했습니다.

## 주요 변경
- `app/(dashboard)/candidate/profile/page.tsx`
- `components/ui/post-status.tsx`
- `lib/i18n/messages/en.ts`
- `lib/i18n/messages/ko.ts`
- `lib/i18n/messages/vi.ts`
- `__tests__/app/candidate-profile-page.test.tsx`
- `todo.md`
- `docs/folder-structure.md`
- `docs/project-state.md`
- `docs/project-state-requirements.md`

## 검증
- `pnpm test` (71 suites, 459 tests 통과)
- `pnpm exec tsc --noEmit` 통과

## 범위
- `fix_needed.md` 기준 item #1만 처리했습니다.
