### PR TITLE
fix(markdown): 채용공고·공지 상세 마크다운 스타일 정렬

### DIFF
--- a/__tests__/app/announcement-detail-page.test.tsx
+++ b/__tests__/app/announcement-detail-page.test.tsx
@@ -35,6 +35,16 @@ const mockGetAnnouncementById = getAnnouncementById as unknown as jest.Mock;
 const mockGetAnnouncementNeighbors =
   getAnnouncementNeighbors as unknown as jest.Mock;
 const mockNotFound = notFound as unknown as jest.Mock;
+const ANNOUNCEMENT_MARKDOWN_FIXTURE = [
+  '## About Us',
+  '',
+  'Announcement body paragraph.',
+  '',
+  '## Responsibilities',
+  '',
+  '- Publish release notes',
+  '- Share operational updates',
+].join('\n');
 
 describe('AnnouncementDetailPage', () => {
   beforeEach(() => {
@@ -47,7 +57,7 @@ describe('AnnouncementDetailPage', () => {
       data: {
         id: 'ann-1',
         title: 'About Vridge',
-        content: '안내 본문',
+        content: ANNOUNCEMENT_MARKDOWN_FIXTURE,
         isPinned: true,
         createdAt: new Date('2026-02-06T00:00:00.000Z'),
         updatedAt: new Date('2026-02-06T00:00:00.000Z'),
@@ -84,9 +94,17 @@ describe('AnnouncementDetailPage', () => {
     expect(heading).toHaveClass('text-[30px]', 'leading-[1.5]');
     expect(screen.getByText('(Pinned)')).toBeInTheDocument();
 
-    const contentText = screen.getByText('안내 본문');
-    const contentCard =
-      contentText.closest('div')?.parentElement?.parentElement;
+    const markdownText = screen.getByText(/## About Us/);
+    const markdownWrapper = markdownText.closest('div')?.parentElement;
+    expect(markdownWrapper).toHaveClass(
+      'text-[18px]',
+      '[&_h2]:text-[22px]',
+      '[&_ul]:list-disc',
+      '[&_ul]:pl-[27px]',
+      '[&_li]:mb-[4px]'
+    );
+
+    const contentCard = markdownWrapper?.parentElement;
     expect(contentCard).toHaveClass(
       'bg-[#fbfbfb]',
       'rounded-[20px]',

--- a/__tests__/app/job-detail-page.test.tsx
+++ b/__tests__/app/job-detail-page.test.tsx
@@ -98,6 +98,16 @@ const mockHeaders = headers as unknown as jest.Mock;
 const mockGetSession = auth.api.getSession as unknown as jest.Mock;
 const mockGetJobDescriptionById = getJobDescriptionById as unknown as jest.Mock;
 const mockGetMyApplications = getMyApplications as unknown as jest.Mock;
+const JOB_MARKDOWN_FIXTURE = [
+  '## About Us',
+  '',
+  'Vridge builds practical ATS workflows.',
+  '',
+  '## Responsibilities',
+  '',
+  '- Build and deliver roadmap items.',
+  '- Collaborate with product and design.',
+].join('\n');
 
 describe('JobDetailPage', () => {
   beforeEach(() => {
@@ -111,7 +121,7 @@ describe('JobDetailPage', () => {
       data: {
         id: 'jd-1',
         title: '[Likelion] UXUI Designer / Full-time / 3+ Years',
-        descriptionMarkdown: '## About Us\ncontent',
+        descriptionMarkdown: JOB_MARKDOWN_FIXTURE,
         createdAt: new Date('2026-02-16T00:00:00.000Z'),
         workArrangement: 'remote',
         minYearsExperience: 3,
@@ -146,6 +156,25 @@ describe('JobDetailPage', () => {
       'data-allow-withdraw',
       'false'
     );
+
+    const markdownText = screen.getByText(/## About Us/);
+    const markdownWrapper = markdownText.closest('div')?.parentElement;
+    expect(markdownWrapper).toHaveClass(
+      'text-[18px]',
+      '[&_h2]:text-[22px]',
+      '[&_ul]:list-disc',
+      '[&_ul]:pl-[27px]',
+      '[&_li]:mb-[4px]'
+    );
+    const markdownCard = markdownWrapper?.parentElement;
+    expect(markdownCard).toHaveClass(
+      'bg-[#fbfbfb]',
+      'rounded-[20px]',
+      'px-[40px]',
+      'pt-[20px]',
+      'pb-[40px]'
+    );
+
     expect(screen.getByRole('button', { name: 'Share' })).toBeInTheDocument();
     expect(screen.queryByTestId('login-to-apply-cta')).toBeNull();
   });

--- a/app/announcements/[id]/page.tsx
+++ b/app/announcements/[id]/page.tsx
@@ -68,7 +68,7 @@ export default async function AnnouncementDetailPage({
       </div>
 
       <div className="rounded-[20px] bg-[#fbfbfb] px-[20px] pt-[20px] pb-[40px]">
-        <div className="text-[18px] leading-[1.5] font-medium text-[#333] [&_li]:mb-[4px] [&_li:last-child]:mb-0 [&_p]:mb-[14px] [&_p:last-child]:mb-0 [&_ul]:my-[14px] [&_ul]:list-disc [&_ul]:pl-[27px]">
+        <div className="text-[18px] leading-[1.5] font-medium text-[#4c4c4c] [&_h2]:mb-[40px] [&_h2]:border-b [&_h2]:border-[#d7d7d7] [&_h2]:pb-[10px] [&_h2]:text-[22px] [&_h2]:leading-[1.5] [&_h2]:font-bold [&_h2]:text-[#1a1a1a] [&_h2:not(:first-of-type)]:mt-[80px] [&_li]:mb-[4px] [&_li:last-child]:mb-0 [&_p]:m-0 [&_ul]:m-0 [&_ul]:list-disc [&_ul]:pl-[27px]">
           <ReactMarkdown>{announcement.content}</ReactMarkdown>
         </div>
       </div>

--- a/app/jobs/[id]/page.tsx
+++ b/app/jobs/[id]/page.tsx
@@ -72,8 +72,8 @@ export default async function JobDetailPage({
         />
 
         {jd.descriptionMarkdown && (
-          <div className="w-full rounded-[20px] bg-[#fbfbfb] px-[40px] py-[20px]">
-            <div className="prose prose-sm max-w-none text-[#4c4c4c]">
+          <div className="w-full rounded-[20px] bg-[#fbfbfb] px-[40px] pt-[20px] pb-[40px]">
+            <div className="text-[18px] leading-[1.5] font-medium text-[#4c4c4c] [&_h2]:mb-[40px] [&_h2]:border-b [&_h2]:border-[#d7d7d7] [&_h2]:pb-[10px] [&_h2]:text-[22px] [&_h2]:leading-[1.5] [&_h2]:font-bold [&_h2]:text-[#1a1a1a] [&_h2:not(:first-of-type)]:mt-[80px] [&_li]:mb-[4px] [&_li:last-child]:mb-0 [&_p]:m-0 [&_ul]:m-0 [&_ul]:list-disc [&_ul]:pl-[27px]">
               <ReactMarkdown>{jd.descriptionMarkdown}</ReactMarkdown>
             </div>
           </div>


### PR DESCRIPTION
## 변경 사항
- app/jobs/[id]/page.tsx에서 prose 기반 마크다운 스타일을 제거하고, Figma 정렬 셀렉터 클래스(h2, ul/li, p)를 명시적으로 적용했습니다.
- app/announcements/[id]/page.tsx의 Announcement.content 렌더링에도 동일한 마크다운 스타일 전략을 적용했습니다.
- __tests__/app/job-detail-page.test.tsx에 마크다운 스타일 계약(헤딩/리스트)과 카드 spacing 클래스 검증을 추가했습니다.
- __tests__/app/announcement-detail-page.test.tsx에 동일한 마크다운 스타일 계약 검증을 추가했습니다.

## 테스트
- pnpm exec jest --runTestsByPath __tests__/app/job-detail-page.test.tsx 통과
- pnpm exec jest --runTestsByPath __tests__/app/announcement-detail-page.test.tsx 통과
- pnpm exec tsc --noEmit 통과
