### PR TITLE
fix: 시드된 데이터 패스워드 기준에 맞게 수정

### DIFF
--- a/docs/test-db-local-setup.md
+++ b/docs/test-db-local-setup.md
@@ -62,14 +62,14 @@ pnpm db:test:reset
 
 `prisma/seed.ts`에서 email/password 로그인 가능한 credential 계정을 함께 생성합니다.
 
-- candidate: `candidate@likelion.net` / `@Aaa111`
-- recruiter: `recruiter@likelion.net` / `@Aaa111`
-- admin: `likelion@likelion.net` / `@Aaa111`
+- candidate: `candidate@likelion.net` / `@Aaa111!`
+- recruiter: `recruiter@likelion.net` / `@Aaa111!`
+- admin: `likelion@likelion.net` / `@Aaa111!`
 
 추가 후보자 계정:
 
-- candidate: `anh.nguyen@example.com` / `@Aaa111`
-- candidate: `seed.candidate1@likelion.net` / `@Aaa111` (이후 번호 증가)
+- candidate: `anh.nguyen@example.com` / `@Aaa111!`
+- candidate: `seed.candidate1@likelion.net` (candidate1, candidate2, ...) / `@Aaa111!`
 
 > 주의: 위 비밀번호는 로컬 테스트 전용 고정값입니다. 운영/공용 환경에서 사용 금지.
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -66,7 +66,7 @@ const SEED_BUILD_CONFIG: SeedBuildConfig = {
   targetAnnouncementCount: 100,
 };
 
-const CANONICAL_PASSWORD = '@Aaa111';
+const CANONICAL_PASSWORD = '@Aaa111!';
 
 const BASE_SAMPLE_JOB_DESCRIPTIONS: SampleJobDescriptionSeed[] = [
   {
@@ -874,9 +874,9 @@ async function seedSampleCredentialAccounts(users: SampleUserSeed[]) {
 
   console.log('시드 완료: credential 계정 생성/갱신');
   console.log('테스트 로그인 계정');
-  console.log('  candidate: candidate@likelion.net / @Aaa111');
-  console.log('  recruiter: recruiter@likelion.net / @Aaa111');
-  console.log('  admin: likelion@likelion.net / @Aaa111');
+  console.log('  candidate: candidate@likelion.net / @Aaa111!');
+  console.log('  recruiter: recruiter@likelion.net / @Aaa111!');
+  console.log('  admin: likelion@likelion.net / @Aaa111!');
 }
 
 async function seedSampleApplies(applies: SampleApplySeed[]) {


### PR DESCRIPTION
## 🔥 PR 제목

fix: 시드된 데이터 패스워드 기준에 맞게 수정

## ✨ 작업 내용

- 시드된 계정 정보가 계정 생성의 기준인 비밀번호 8자가 넘지 않아 수정
- 시드된 계정 정보의 수정에 따른 문서의 수정

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

