### PR TITLE
chore(ci): Prisma 마이그레이션 배포 워크플로 하드닝

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - prisma/migrations/**
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-migrations-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Prisma Migration Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate required secrets
+        run: |
+          test -n "${DATABASE_URL}"
+          test -n "${DIRECT_URL}"
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}
+
+      - name: Apply pending migrations
+        run: pnpm exec prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DIRECT_URL: ${{ secrets.DIRECT_URL }}

--- a/docs/supabase-migration-v0.1-runbook.md
+++ b/docs/supabase-migration-v0.1-runbook.md
@@ -45,7 +45,7 @@ ls prisma/migrations
 ```bash
 DATABASE_URL='postgresql://<user>:<password>@<host>:5432/<db_name>?sslmode=require' \
 DIRECT_URL='postgresql://<user>:<password>@<host>:5432/<db_name>?sslmode=require' \
-pnpm db:prod:migrate
+pnpm exec prisma migrate deploy
 ```
 
 내부적으로 실행되는 명령:
@@ -164,7 +164,7 @@ from generate_series(1, 5);
 배포 중:
 
 - 운영 direct URL 사용 확인
-- `pnpm db:prod:migrate` 성공 확인
+- `pnpm exec prisma migrate deploy` 성공 확인
 - `pnpm db:prod:seed:v0.1` 성공 확인
 
 배포 후:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "db:test:push": "sh -c 'set -a; . ./.env.test; set +a; prisma db execute --file prisma/bootstrap.sql && prisma db push --accept-data-loss'",
     "db:test:seed": "sh -c 'set -a; . ./.env.test; set +a; prisma db seed'",
     "db:test:reset": "sh -c 'set -a; . ./.env.test; set +a; printf \"%s\\n\" \"drop schema if exists public cascade;\" \"create schema public;\" | prisma db execute --stdin && prisma db execute --file prisma/bootstrap.sql && prisma db push --accept-data-loss && prisma db seed'",
-    "db:prod:migrate": "prisma migrate deploy",
     "db:prod:seed:v0.1": "sh -c 'SEED_SCOPE=prod_v0_1_core3 prisma db seed'",
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## 요약

Prisma 마이그레이션 운영 배포 흐름을 CI/CD 기준으로 정리하고, 배포 워크플로를 하드닝했습니다.

- 로컬 `db:prod:migrate` 스크립트 제거
- `push main + prisma/migrations/**` 조건의 배포 워크플로 추가/정비
- 워크플로에 pnpm/node 캐시, 필수 시크릿 검증, 동시 실행 제어 추가
- 런북 문서의 명령어를 실제 운영 경로(`pnpm exec prisma migrate deploy`)에 맞게 동기화

## 변경 파일

- `.github/workflows/deploy.yml`
- `package.json`
- `docs/supabase-migration-v0.1-runbook.md`

## 상세 변경

### 1) 배포 워크플로 하드닝

- 트리거: `push` on `main` + `paths: prisma/migrations/**`
- `permissions: contents: read`
- `concurrency` 추가 (중복 실행 방지)
- `pnpm/action-setup@v4` + `setup-node` 캐시 설정
- `DATABASE_URL`, `DIRECT_URL` 시크릿 존재 검증 단계 추가
- 마이그레이션 적용 명령: `pnpm exec prisma migrate deploy`

### 2) 스크립트 정리

- `package.json`에서 `db:prod:migrate` 제거
- 운영 마이그레이션 실행은 CI 워크플로 기준으로 일원화

### 3) 문서 정합성 업데이트

- 런북에서 `pnpm db:prod:migrate`를 `pnpm exec prisma migrate deploy`로 교체
- 체크리스트 문구 동일하게 정리

## 검증

- `pnpm exec prettier --check .github/workflows/deploy.yml package.json docs/supabase-migration-v0.1-runbook.md`
