### PR TITLE
fix: globals 타이포 토큰 Figma 정합성 마무리

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -85,73 +85,70 @@
   --color-text-sub-2: var(--color-gray-500);
   --color-text-info: var(--color-gray-400);
 
-  --font-family-base: var(--font-inter);
-  --font-family-display: 'Helvetica Now Display', 'Inter', sans-serif;
-
-  --typography-label-normal-font-family: var(--font-family-base);
+  --typography-label-normal-font-family: var(--font-inter);
   --typography-label-normal-font-size: 1rem;
   --typography-label-normal-font-weight: 500;
-  --typography-label-normal-line-height: 1.5rem;
+  --typography-label-normal-line-height: 1.5;
   --typography-label-normal-letter-spacing: 0;
 
-  --typography-title-font-family: var(--font-family-display);
+  --typography-title-font-family: var(--font-inter);
   --typography-title-font-size: 1.875rem;
   --typography-title-font-weight: 700;
-  --typography-title-line-height: 2.8125rem;
-  --typography-title-letter-spacing: 0.025em;
+  --typography-title-line-height: 1.5;
+  --typography-title-letter-spacing: 0;
 
-  --typography-h1-font-family: var(--font-family-display);
+  --typography-h1-font-family: var(--font-inter);
   --typography-h1-font-size: 1.625rem;
   --typography-h1-font-weight: 700;
-  --typography-h1-line-height: 2.4375rem;
-  --typography-h1-letter-spacing: 0.025em;
+  --typography-h1-line-height: 1.5;
+  --typography-h1-letter-spacing: 0;
 
-  --typography-h2-font-family: var(--font-family-base);
+  --typography-h2-font-family: var(--font-inter);
   --typography-h2-font-size: 1.375rem;
   --typography-h2-font-weight: 700;
-  --typography-h2-line-height: 2.0625rem;
+  --typography-h2-line-height: 1.5;
   --typography-h2-letter-spacing: 0;
 
-  --typography-h3-font-family: var(--font-family-base);
+  --typography-h3-font-family: var(--font-inter);
   --typography-h3-font-size: 1.25rem;
   --typography-h3-font-weight: 700;
-  --typography-h3-line-height: 1.875rem;
+  --typography-h3-line-height: 1.5;
   --typography-h3-letter-spacing: 0;
 
-  --typography-h4-font-family: var(--font-family-base);
+  --typography-h4-font-family: var(--font-inter);
   --typography-h4-font-size: 1.25rem;
   --typography-h4-font-weight: 500;
-  --typography-h4-line-height: 1.875rem;
+  --typography-h4-line-height: 1.5;
   --typography-h4-letter-spacing: 0;
 
-  --typography-body-1-font-family: var(--font-family-base);
+  --typography-body-1-font-family: var(--font-inter);
   --typography-body-1-font-size: 1.125rem;
   --typography-body-1-font-weight: 500;
-  --typography-body-1-line-height: 1.6875rem;
+  --typography-body-1-line-height: 1.5;
   --typography-body-1-letter-spacing: 0;
 
-  --typography-body-2-strong-font-family: var(--font-family-base);
+  --typography-body-2-strong-font-family: var(--font-inter);
   --typography-body-2-strong-font-size: 1rem;
   --typography-body-2-strong-font-weight: 700;
-  --typography-body-2-strong-line-height: 1.5rem;
+  --typography-body-2-strong-line-height: 1.5;
   --typography-body-2-strong-letter-spacing: 0;
 
-  --typography-body-2-font-family: var(--font-family-base);
+  --typography-body-2-font-family: var(--font-inter);
   --typography-body-2-font-size: 1rem;
   --typography-body-2-font-weight: 500;
-  --typography-body-2-line-height: 1.5rem;
+  --typography-body-2-line-height: 1.5;
   --typography-body-2-letter-spacing: 0;
 
-  --typography-caption-1-font-family: var(--font-family-base);
+  --typography-caption-1-font-family: var(--font-inter);
   --typography-caption-1-font-size: 0.875rem;
   --typography-caption-1-font-weight: 500;
-  --typography-caption-1-line-height: 1.3125rem;
+  --typography-caption-1-line-height: 1.5;
   --typography-caption-1-letter-spacing: 0;
 
-  --typography-caption-2-font-family: var(--font-family-base);
+  --typography-caption-2-font-family: var(--font-inter);
   --typography-caption-2-font-size: 0.75rem;
   --typography-caption-2-font-weight: 500;
-  --typography-caption-2-line-height: 1.125rem;
+  --typography-caption-2-line-height: 1.5;
   --typography-caption-2-letter-spacing: 0;
 }
 
@@ -160,7 +157,6 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-family-base);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);


### PR DESCRIPTION
## 변경 사항
- app/globals.css 타이포 토큰을 Figma 기준으로 정리했습니다.
- Figma의 150% line-height 기준을 unitless 1.5로 통일했습니다.
- typography-caption-1-letter-spacing: 0 결정을 유지했습니다.
- 사용되지 않는 --font-sans: var(--font-family-base);를 제거하고, --font-family-base 잔여 참조를 없앴습니다.

## 검증
- 색상 토큰 정합성 스크립트 통과 (ColorSystem 248:12445 기준)
- 타이포 토큰 정합성 스크립트 통과 (TypoSystem 248:12442 기준, 150%=1.5 기준)
- rg로 font-family-base/--font-sans 참조 없음 확인 (app/frontend/shared)
- pnpm lint 통과

## 범위
- 변경 파일: app/globals.css