### PR TITLE
docs(agents): AGENTS/CLAUDE 계획·프리플라이트·PR/gh 권한 규칙 명확화

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,35 @@ Rule #1: If you want exception to ANY rule, YOU MUST STOP and get explicit permi
 - Keep in the main conversation: implementation, iterative work, decisions requiring context
 - Agents don't share context with each other — route information through the main conversation
 
+## Planning and Task handling
+
+- YOU MUST ALWAYS create an executable step-by-step plan where each step includes: action intent, exact command/action, and done-check.
+- YOU MUST NEVER assume executor context. Every handoff MUST include: goal, scope, constraints, exact steps/commands, touched files, and acceptance checks.
+- If new evidence invalidates the plan, YOU MUST pause, publish a plan delta, and continue only after the revised steps are explicit.
+
+### Preflight 1: Feature Branch Creation (BEFORE implementing plan)
+
+- ALWAYS identify the remote default base branch (for example `origin/HEAD` -> `main` or `master`).
+- ALWAYS update the base branch using fetch + fast-forward-only. If sync fails, STOP and ask Ori.
+- ALWAYS create a feature branch using `type/scope-topic` naming.
+- ALWAYS use `git worktree` by default. A normal branch checkout is allowed only when work is single-threaded or worktree setup is blocked.
+- ALWAYS ensure dependencies are ready when needed. Use manager-native strict install only if lock/manifests changed, dependencies are missing, or bootstrap fails (`pnpm install --frozen-lockfile`, `yarn install --immutable`, `npm ci`).
+
+### Preflight 2: Issue Opening (BEFORE implementing plan)
+
+- ALWAYS open an Issue unless Ori explicitly provided an existing issue ID or URL.
+- ALWAYS choose template by intent: defect/debug work uses bug report template; feature/refactor/task work uses feature request template.
+- ALWAYS use a template if one exists.
+- YOU MUST fill all required sections. If a required section is not applicable, write `N/A` with a reason.
+
+### Cleanup: PR Opening
+
+- ALWAYS open a PR for merge-intent changes.
+- ALWAYS use a template if one exists.
+- YOU MUST fill all required sections. If a required section is not applicable, write `N/A` with a reason.
+- ALWAYS keep the linked Issue open during review and close it on merge/completion, not at PR creation.
+- If PR creation is blocked by auth/permission/remote issues, STOP and ask Ori with branch name, commit status, and blocker details.
+
 ## Systematic Debugging Process
 
 YOU MUST ALWAYS find the root cause of any issue you are debugging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,4 +161,4 @@ YOU MUST follow this debugging framework for ANY technical issue:
 ## Sandboxing
 
 - In sandboxed environments, treat `pnpm build` as a concrete example of a script that may require elevated permissions; ask Ori before requesting escalation.
-- If `gh pr create` fails, DO NOT assume `gh auth login` is missing; treat it as a separate failure mode first and ask Ori before escalating.
+- In sandboxed environments, assume every `gh` command failure is permission related and ask Ori for permissions before continuing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,29 @@ Rule #1: If you want exception to ANY rule, YOU MUST STOP and get explicit permi
 - Keep in the main conversation: implementation, iterative work, decisions requiring context
 - Agents don't share context with each other — route information through the main conversation
 
+### Preflight 1: Feature Branch Creation (BEFORE implementing plan)
+
+- ALWAYS identify the remote default base branch (for example `origin/HEAD` -> `main` or `master`).
+- ALWAYS update the base branch using fetch + fast-forward-only. If sync fails, STOP and ask Ori.
+- ALWAYS create a feature branch using `type/scope-topic` naming.
+- ALWAYS use `git worktree` by default. A normal branch checkout is allowed only when work is single-threaded or worktree setup is blocked.
+- ALWAYS ensure dependencies are ready when needed. Use manager-native strict install only if lock/manifests changed, dependencies are missing, or bootstrap fails (`pnpm install --frozen-lockfile`, `yarn install --immutable`, `npm ci`).
+
+### Preflight 2: Issue Opening (BEFORE implementing plan)
+
+- ALWAYS open an Issue unless Ori explicitly provided an existing issue ID or URL.
+- ALWAYS choose template by intent: defect/debug work uses bug report template; feature/refactor/task work uses feature request template.
+- ALWAYS use a template if one exists.
+- YOU MUST fill all required sections. If a required section is not applicable, write `N/A` with a reason.
+
+### Cleanup: PR Opening
+
+- ALWAYS open a PR for merge-intent changes.
+- ALWAYS use a template if one exists.
+- YOU MUST fill all required sections. If a required section is not applicable, write `N/A` with a reason.
+- ALWAYS keep the linked Issue open during review and close it on merge/completion, not at PR creation.
+- If PR creation is blocked by auth/permission/remote issues, STOP and ask Ori with branch name, commit status, and blocker details.
+
 ## Systematic Debugging Process
 
 YOU MUST ALWAYS find the root cause of any issue you are debugging


### PR DESCRIPTION
Closes #65

## 🔥 PR 제목

> docs(agents): AGENTS/CLAUDE 계획·프리플라이트·PR/gh 권한 규칙 명확화

## ✨ 작업 내용

- `AGENTS.md`의 Planning and Task handling, Preflight 1/2, Cleanup 규칙을 실행 기준이 명확한 문장으로 교체했습니다.
- `CLAUDE.md`에 동일한 프리플라이트/이슈/PR 처리 규칙을 반영했습니다.
- Sandboxing 규칙에 `gh` 명령 실패를 권한 이슈로 간주하고 Ori에게 권한 요청하도록 명시했습니다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- 커밋 훅에서 다음 검증이 통과했습니다.
  - `pnpm exec tsc --noEmit`
  - `pnpm exec prisma validate`
  - `pnpm exec lint-staged`
- 본 변경은 문서/규칙 정리 중심이라 별도 E2E 시나리오는 `N/A`입니다.

## 📸 스크린샷 / 시연 (선택)

- N/A (문서 규칙 변경으로 UI 변경 없음)

## 🙏 리뷰어에게 한마디

- 운영 규칙 문장 해석 차이를 줄이기 위한 변경입니다. 워크플로우 충돌 가능성이 보이면 구체 사례와 함께 코멘트 부탁드립니다.
