### PR TITLE
refactor(design-token): 프론트엔드 전반 디자인 토큰 클래스 전면 적용

### DIFF
--- a/__tests__/components/ui/button-brand.test.tsx
+++ b/__tests__/components/ui/button-brand.test.tsx
@@ -6,7 +6,7 @@ describe('Button brand variants', () => {
     it('brand 배경 + 흰색 텍스트', () => {
       render(<Button variant="brand">Apply</Button>);
       const btn = screen.getByRole('button', { name: 'Apply' });
-      expect(btn).toHaveClass('bg-[#ff6000]');
+      expect(btn).toHaveClass('bg-brand');
       expect(btn).toHaveClass('text-white');
       expect(btn).toHaveClass('rounded-[60px]');
     });
@@ -16,8 +16,8 @@ describe('Button brand variants', () => {
     it('brand 테두리 + brand 텍스트', () => {
       render(<Button variant="brand-outline">Cancel</Button>);
       const btn = screen.getByRole('button', { name: 'Cancel' });
-      expect(btn).toHaveClass('border-[#ff6000]');
-      expect(btn).toHaveClass('text-[#ff6000]');
+      expect(btn).toHaveClass('border-brand');
+      expect(btn).toHaveClass('text-brand');
       expect(btn).toHaveClass('bg-white');
       expect(btn).toHaveClass('rounded-[60px]');
     });
@@ -27,7 +27,7 @@ describe('Button brand variants', () => {
     it('회색 배경 + 흰색 텍스트 + cursor-not-allowed', () => {
       render(<Button variant="brand-disabled">Disabled</Button>);
       const btn = screen.getByRole('button', { name: 'Disabled' });
-      expect(btn).toHaveClass('bg-[#ccc]');
+      expect(btn).toHaveClass('bg-gray-200');
       expect(btn).toHaveClass('text-white');
       expect(btn).toHaveClass('cursor-not-allowed');
       expect(btn).toHaveClass('rounded-[60px]');

--- a/__tests__/components/ui/chip.test.tsx
+++ b/__tests__/components/ui/chip.test.tsx
@@ -7,11 +7,9 @@ describe('Chip', () => {
     it('기본 스타일: 흰 배경 + 회색 테두리', () => {
       render(<Chip label="React" variant="displayed" />);
       const chip = screen.getByText('React');
-      expect(chip.closest('[data-slot="chip"]')).toHaveClass(
-        'border-[#b3b3b3]'
-      );
+      expect(chip.closest('[data-slot="chip"]')).toHaveClass('border-gray-300');
       expect(chip.closest('[data-slot="chip"]')).toHaveClass('bg-white');
-      expect(chip.closest('[data-slot="chip"]')).toHaveClass('text-[#666]');
+      expect(chip.closest('[data-slot="chip"]')).toHaveClass('text-gray-600');
     });
 
     it('close 아이콘 없음', () => {
@@ -46,7 +44,7 @@ describe('Chip', () => {
     it('오렌지 테두리', () => {
       render(<Chip label="React" variant="selected" />);
       const chip = screen.getByText('React').closest('[data-slot="chip"]');
-      expect(chip).toHaveClass('border-[#ff904c]');
+      expect(chip).toHaveClass('border-orange-200');
     });
 
     it('체크 아이콘 표시', () => {
@@ -77,8 +75,8 @@ describe('Chip', () => {
       expect(chip).toHaveClass('border-[0.5px]');
       expect(chip).toHaveClass('px-[8px]');
       expect(chip).toHaveClass('py-[6px]');
-      expect(chip).toHaveClass('text-[14px]');
-      expect(chip).toHaveClass('text-[#666]');
+      expect(chip).toHaveClass('text-caption-1');
+      expect(chip).toHaveClass('text-gray-600');
     });
 
     it('md: 중간 사이즈', () => {
@@ -87,8 +85,8 @@ describe('Chip', () => {
       expect(chip).toHaveClass('border');
       expect(chip).toHaveClass('px-[10px]');
       expect(chip).toHaveClass('py-[8px]');
-      expect(chip).toHaveClass('text-[16px]');
-      expect(chip).toHaveClass('text-[#4c4c4c]');
+      expect(chip).toHaveClass('text-body-2');
+      expect(chip).toHaveClass('text-gray-700');
     });
   });
 });

--- a/__tests__/components/ui/form-dropdown.test.tsx
+++ b/__tests__/components/ui/form-dropdown.test.tsx
@@ -20,7 +20,7 @@ describe('FormDropdown', () => {
     expect(screen.getByText('Select')).toBeInTheDocument();
   });
 
-  it('기본 배경: bg-[#fbfbfb]', () => {
+  it('기본 배경: bg-bg', () => {
     render(
       <FormDropdown
         options={OPTIONS}
@@ -29,7 +29,7 @@ describe('FormDropdown', () => {
       />
     );
     const trigger = screen.getByRole('button');
-    expect(trigger).toHaveClass('bg-[#fbfbfb]');
+    expect(trigger).toHaveClass('bg-bg');
   });
 
   it('클릭 시 옵션 목록 표시', async () => {
@@ -74,7 +74,7 @@ describe('FormDropdown', () => {
     const trigger = screen.getByRole('button');
     expect(screen.getByText('React')).toBeInTheDocument();
     expect(trigger).toHaveClass('bg-white');
-    expect(trigger).toHaveClass('border-[#b3b3b3]');
+    expect(trigger).toHaveClass('border-gray-300');
   });
 
   it('chevron-down 아이콘 렌더링', () => {
@@ -132,7 +132,7 @@ describe('FormDropdown', () => {
     await user.click(screen.getByRole('button'));
     const option = screen.getByRole('button', { name: 'React' });
 
-    expect(option).toHaveClass('hover:bg-[#ffefe5]');
-    expect(option).toHaveClass('hover:text-[#ff6000]');
+    expect(option).toHaveClass('hover:bg-brand-sub');
+    expect(option).toHaveClass('hover:text-brand');
   });
 });

--- a/__tests__/components/ui/form-input.test.tsx
+++ b/__tests__/components/ui/form-input.test.tsx
@@ -22,17 +22,17 @@ describe('FormInput', () => {
     expect(textarea).toHaveClass('h-[130px]');
   });
 
-  it('기본 상태: bg-[#fbfbfb] 배경', () => {
+  it('기본 상태: bg-bg 배경', () => {
     renderWithI18n(<FormInput placeholder="Test" />);
     const input = screen.getByPlaceholderText('Test');
-    expect(input).toHaveClass('bg-[#fbfbfb]');
+    expect(input).toHaveClass('bg-bg');
   });
 
   it('filled 상태: bg-white + border', () => {
     renderWithI18n(<FormInput placeholder="Test" filled />);
     const input = screen.getByPlaceholderText('Test');
     expect(input).toHaveClass('bg-white');
-    expect(input).toHaveClass('border-[#b3b3b3]');
+    expect(input).toHaveClass('border-gray-300');
   });
 
   it('모든 사이즈 rounded-[10px]', () => {

--- a/__tests__/components/ui/login-field.test.tsx
+++ b/__tests__/components/ui/login-field.test.tsx
@@ -14,7 +14,7 @@ describe('LoginField', () => {
     );
 
     expect(screen.getByPlaceholderText('Placeholder')).toHaveClass(
-      'text-[#999]'
+      'text-gray-400'
     );
   });
 
@@ -29,7 +29,7 @@ describe('LoginField', () => {
       />
     );
 
-    expect(screen.getByDisplayValue('filled')).toHaveClass('text-[#333]');
+    expect(screen.getByDisplayValue('filled')).toHaveClass('text-gray-800');
   });
 
   it('left icon과 right slot을 렌더링한다', () => {

--- a/__tests__/components/ui/numbered-pagination.test.tsx
+++ b/__tests__/components/ui/numbered-pagination.test.tsx
@@ -37,7 +37,7 @@ describe('NumberedPagination', () => {
     }
   });
 
-  it('현재 페이지 활성 스타일: bg-[#ffefe5] text-[#ff6000]', () => {
+  it('현재 페이지 활성 스타일: bg-brand-sub text-brand', () => {
     render(
       <NumberedPagination
         currentPage={3}
@@ -48,8 +48,8 @@ describe('NumberedPagination', () => {
       />
     );
     const active = screen.getByText('3');
-    expect(active).toHaveClass('bg-[#ffefe5]');
-    expect(active).toHaveClass('text-[#ff6000]');
+    expect(active).toHaveClass('bg-brand-sub');
+    expect(active).toHaveClass('text-brand');
     expect(active).toHaveClass('h-[24px]');
     expect(active).toHaveClass('w-[24px]');
   });

--- a/__tests__/components/ui/post-status.test.tsx
+++ b/__tests__/components/ui/post-status.test.tsx
@@ -6,14 +6,14 @@ describe('PostStatus', () => {
   it('recruiting 상태: 초록색 텍스트', () => {
     renderWithI18n(<PostStatus status="recruiting" />);
     const text = screen.getByText('Recruiting');
-    expect(text).toHaveClass('text-[#00a600]');
+    expect(text).toHaveClass('text-success');
     expect(text.parentElement).toHaveClass('gap-[2px]');
   });
 
   it('done 상태: 빨간색 텍스트', () => {
     renderWithI18n(<PostStatus status="done" />);
     const text = screen.getByText('Done');
-    expect(text).toHaveClass('text-[#e50000]');
+    expect(text).toHaveClass('text-error');
   });
 
   it('recruiting 아이콘 렌더링', () => {
@@ -31,13 +31,13 @@ describe('PostStatus', () => {
   it('sm 사이즈: text-[12px]', () => {
     renderWithI18n(<PostStatus status="recruiting" size="sm" />);
     const text = screen.getByText('Recruiting');
-    expect(text).toHaveClass('text-[12px]');
+    expect(text).toHaveClass('text-caption-2');
   });
 
   it('md 사이즈: text-[14px]', () => {
     renderWithI18n(<PostStatus status="recruiting" size="md" />);
     const text = screen.getByText('Recruiting');
-    expect(text).toHaveClass('text-[14px]');
+    expect(text).toHaveClass('text-caption-1');
   });
 
   it('커스텀 label 적용', () => {

--- a/__tests__/components/ui/search-bar.test.tsx
+++ b/__tests__/components/ui/search-bar.test.tsx
@@ -14,7 +14,7 @@ describe('SearchBar', () => {
     );
     const input = screen.getByPlaceholderText('Search');
     expect(input).toHaveClass('rounded-[60px]');
-    expect(input).toHaveClass('border-[#b3b3b3]');
+    expect(input).toHaveClass('border-gray-300');
   });
 
   it('skills variant: bg-[#fbfbfb] 스타일', () => {
@@ -27,9 +27,9 @@ describe('SearchBar', () => {
       />
     );
     const input = screen.getByPlaceholderText('Search skills');
-    expect(input).toHaveClass('bg-[#fbfbfb]');
+    expect(input).toHaveClass('bg-bg');
     expect(input).toHaveClass('rounded-[999px]');
-    expect(input).toHaveClass('text-[14px]');
+    expect(input).toHaveClass('text-caption-1');
   });
 
   it('skills variant: search 아이콘 렌더링', () => {
@@ -81,6 +81,6 @@ describe('SearchBar', () => {
       />
     );
 
-    expect(screen.getByDisplayValue('Frontend')).toHaveClass('text-[#333]');
+    expect(screen.getByDisplayValue('Frontend')).toHaveClass('text-gray-800');
   });
 });

--- a/__tests__/components/ui/section-title.test.tsx
+++ b/__tests__/components/ui/section-title.test.tsx
@@ -8,18 +8,17 @@ describe('SectionTitle', () => {
     expect(screen.getByText('Experience')).toBeInTheDocument();
   });
 
-  it('제목 스타일: text-[22px] font-bold', () => {
+  it('제목 스타일: text-h2', () => {
     render(<SectionTitle title="Experience" />);
     const title = screen.getByText('Experience');
-    expect(title).toHaveClass('text-[22px]');
-    expect(title).toHaveClass('font-bold');
+    expect(title).toHaveClass('text-h2');
   });
 
   it('하단 구분선 렌더링', () => {
     const { container } = render(<SectionTitle title="Experience" />);
     const divider = container.querySelector('.h-px');
     expect(divider).toBeInTheDocument();
-    expect(divider).toHaveClass('bg-[#b3b3b3]');
+    expect(divider).toHaveClass('bg-gray-300');
   });
 
   it('onAdd 없을 때 추가 버튼 미표시', () => {

--- a/__tests__/components/ui/tab-item.test.tsx
+++ b/__tests__/components/ui/tab-item.test.tsx
@@ -16,7 +16,7 @@ describe('TabItem', () => {
   it('비활성 상태: 기본 스타일', () => {
     render(<TabItem label="Jobs" isActive={false} href="/jobs" />);
     const link = screen.getByRole('link', { name: 'Jobs' });
-    expect(link).toHaveClass('text-[16px]');
+    expect(link).toHaveClass('text-body-2');
     expect(link).toHaveClass('border-gray-100');
     expect(link).not.toHaveClass('text-brand');
   });
@@ -28,6 +28,6 @@ describe('TabItem', () => {
     expect(link).toHaveClass('border-b');
     expect(link).toHaveClass('border-brand');
     expect(link).toHaveClass('font-bold');
-    expect(link).toHaveClass('text-[16px]');
+    expect(link).toHaveClass('text-body-2');
   });
 });

--- a/__tests__/components/ui/toggle-switch.test.tsx
+++ b/__tests__/components/ui/toggle-switch.test.tsx
@@ -5,13 +5,13 @@ describe('ToggleSwitch', () => {
   it('unchecked 상태: 회색 트랙', () => {
     render(<ToggleSwitch checked={false} onChange={() => {}} />);
     const track = screen.getByRole('switch');
-    expect(track).toHaveClass('bg-[#e6e6e6]');
+    expect(track).toHaveClass('bg-gray-100');
   });
 
   it('checked 상태: 초록색 트랙', () => {
     render(<ToggleSwitch checked={true} onChange={() => {}} />);
     const track = screen.getByRole('switch');
-    expect(track).toHaveClass('bg-[#00a600]');
+    expect(track).toHaveClass('bg-success');
   });
 
   it('aria-checked 속성 반영', () => {

--- a/__tests__/entities/job/posting-title.test.tsx
+++ b/__tests__/entities/job/posting-title.test.tsx
@@ -72,7 +72,7 @@ describe('PostingTitle', () => {
     expect(screen.getByText('Done')).toBeInTheDocument();
   });
 
-  it('타이틀 스타일: text-[30px] font-bold', () => {
+  it('타이틀 스타일: text-title', () => {
     renderWithI18n(
       <PostingTitle
         title="Test Title"
@@ -81,7 +81,6 @@ describe('PostingTitle', () => {
       />
     );
     const title = screen.getByText('Test Title');
-    expect(title).toHaveClass('text-[30px]');
-    expect(title).toHaveClass('font-bold');
+    expect(title).toHaveClass('text-title');
   });
 });

--- a/__tests__/entities/profile/profile-card.test.tsx
+++ b/__tests__/entities/profile/profile-card.test.tsx
@@ -30,7 +30,7 @@ describe('ProfileCard', () => {
     renderWithI18n(<ProfileCard {...baseProps} />);
     const summary = screen.getByText('Building reliable web products');
     expect(summary).toBeInTheDocument();
-    expect(summary).toHaveClass('text-[18px]');
+    expect(summary).toHaveClass('text-body-1');
     expect(
       screen.queryByText('Experienced developer looking for new opportunities')
     ).not.toBeInTheDocument();

--- a/app/(dashboard)/candidate/profile/profile-content.tsx
+++ b/app/(dashboard)/candidate/profile/profile-content.tsx
@@ -504,9 +504,7 @@ function PortfolioSection({ urls, t }: { urls: Url[]; t: Translator }) {
     <section className={`${CARD_CLASS} flex flex-col gap-[40px]`}>
       <SectionTitle title={t('profile.portfolio')} />
       {urls.length === 0 ? (
-        <p className="text-[16px] leading-[1.5] font-medium text-[#666]">
-          {t('profile.empty.urls')}
-        </p>
+        <p className="text-h3 text-text-body-2">{t('profile.empty.urls')}</p>
       ) : (
         <ul className="flex flex-col gap-[20px]">
           {urls.map((item) => (
@@ -515,7 +513,7 @@ function PortfolioSection({ urls, t }: { urls: Url[]; t: Translator }) {
                 href={item.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-[10px] text-[20px] leading-[1.5] font-bold text-[#333] hover:underline"
+                className="inline-flex items-center gap-[10px] text-body-1 text-text-body-1 hover:underline"
               >
                 <Icon name="file" size={24} />
                 <span>{resolvePortfolioLabel(item)}</span>

--- a/app/globals.css
+++ b/app/globals.css
@@ -85,77 +85,46 @@
   --color-text-sub-2: var(--color-gray-500);
   --color-text-info: var(--color-gray-400);
 
-  --typography-label-normal-font-family: var(--font-inter);
-  --typography-label-normal-font-size: 1rem;
-  --typography-label-normal-font-weight: 500;
-  --typography-label-normal-line-height: 1.5;
-  --typography-label-normal-letter-spacing: 0;
+  --text-title: 1.875rem;
+  --text-title--line-height: 1.5;
+  --text-title--font-weight: 700;
 
-  --typography-title-font-family: var(--font-inter);
-  --typography-title-font-size: 1.875rem;
-  --typography-title-font-weight: 700;
-  --typography-title-line-height: 1.5;
-  --typography-title-letter-spacing: 0;
+  --text-h1: 1.625rem;
+  --text-h1--line-height: 1.5;
+  --text-h1--font-weight: 700;
 
-  --typography-h1-font-family: var(--font-inter);
-  --typography-h1-font-size: 1.625rem;
-  --typography-h1-font-weight: 700;
-  --typography-h1-line-height: 1.5;
-  --typography-h1-letter-spacing: 0;
+  --text-h2: 1.375rem;
+  --text-h2--line-height: 1.5;
+  --text-h2--font-weight: 700;
 
-  --typography-h2-font-family: var(--font-inter);
-  --typography-h2-font-size: 1.375rem;
-  --typography-h2-font-weight: 700;
-  --typography-h2-line-height: 1.5;
-  --typography-h2-letter-spacing: 0;
+  --text-h3: 1.25rem;
+  --text-h3--line-height: 1.5;
+  --text-h3--font-weight: 700;
 
-  --typography-h3-font-family: var(--font-inter);
-  --typography-h3-font-size: 1.25rem;
-  --typography-h3-font-weight: 700;
-  --typography-h3-line-height: 1.5;
-  --typography-h3-letter-spacing: 0;
+  --text-h4: 1.25rem;
+  --text-h4--line-height: 1.5;
+  --text-h4--font-weight: 500;
 
-  --typography-h4-font-family: var(--font-inter);
-  --typography-h4-font-size: 1.25rem;
-  --typography-h4-font-weight: 500;
-  --typography-h4-line-height: 1.5;
-  --typography-h4-letter-spacing: 0;
+  --text-body-1: 1.125rem;
+  --text-body-1--line-height: 1.5;
+  --text-body-1--font-weight: 500;
 
-  --typography-body-1-font-family: var(--font-inter);
-  --typography-body-1-font-size: 1.125rem;
-  --typography-body-1-font-weight: 500;
-  --typography-body-1-line-height: 1.5;
-  --typography-body-1-letter-spacing: 0;
+  --text-body-2: 1rem;
+  --text-body-2--line-height: 1.5;
+  --text-body-2--font-weight: 500;
 
-  --typography-body-2-strong-font-family: var(--font-inter);
-  --typography-body-2-strong-font-size: 1rem;
-  --typography-body-2-strong-font-weight: 700;
-  --typography-body-2-strong-line-height: 1.5;
-  --typography-body-2-strong-letter-spacing: 0;
+  --text-body-3: 1rem;
+  --text-body-3--line-height: 1.5;
+  --text-body-3--font-weight: 500;
 
-  --typography-body-2-font-family: var(--font-inter);
-  --typography-body-2-font-size: 1rem;
-  --typography-body-2-font-weight: 500;
-  --typography-body-2-line-height: 1.5;
-  --typography-body-2-letter-spacing: 0;
+  --text-caption-1: 0.875rem;
+  --text-caption-1--line-height: 1.5;
+  --text-caption-1--font-weight: 500;
+  --text-caption-1--letter-spacing: -0.21px;
 
-  --typography-body-3-font-family: var(--font-inter);
-  --typography-body-3-font-size: 1rem;
-  --typography-body-3-font-weight: 500;
-  --typography-body-3-line-height: 1.5;
-  --typography-body-3-letter-spacing: 0;
-
-  --typography-caption-1-font-family: var(--font-inter);
-  --typography-caption-1-font-size: 0.875rem;
-  --typography-caption-1-font-weight: 500;
-  --typography-caption-1-line-height: 1.5;
-  --typography-caption-1-letter-spacing: 0;
-
-  --typography-caption-2-font-family: var(--font-inter);
-  --typography-caption-2-font-size: 0.75rem;
-  --typography-caption-2-font-weight: 500;
-  --typography-caption-2-line-height: 1.5;
-  --typography-caption-2-letter-spacing: 0;
+  --text-caption-2: 0.75rem;
+  --text-caption-2--line-height: 1.5;
+  --text-caption-2--font-weight: 500;
 }
 
 @custom-variant dark (&:is(.dark *));

--- a/frontend/components/analytics/consent-banner.tsx
+++ b/frontend/components/analytics/consent-banner.tsx
@@ -14,24 +14,24 @@ export function ConsentBanner({ onAccept, onReject, privacyPolicyUrl }: Props) {
   const { t } = useI18n();
 
   return (
-    <div className="fixed right-4 bottom-4 left-4 z-50 rounded-xl border border-[#e6e6e6] bg-white p-4 shadow-[0_12px_28px_rgba(0,0,0,0.12)]">
+    <div className="fixed right-4 bottom-4 left-4 z-50 rounded-xl border border-gray-100 bg-white p-4 shadow-[0_12px_28px_rgba(0,0,0,0.12)]">
       <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
         <div className="max-w-[760px] space-y-2">
-          <p className="text-sm font-semibold text-[#1a1a1a]">
+          <p className="text-sm font-semibold text-gray-950">
             {t('analytics.consent.title')}
           </p>
-          <p className="text-sm text-[#4c4c4c]">
+          <p className="text-sm text-gray-700">
             {t('analytics.consent.message')}
           </p>
           {privacyPolicyUrl ? (
             <Link
               href={privacyPolicyUrl}
-              className="text-sm text-[#ff6000] underline underline-offset-2"
+              className="text-sm text-brand underline underline-offset-2"
             >
               {t('analytics.consent.privacyLink')}
             </Link>
           ) : (
-            <p className="text-xs text-[#666]">
+            <p className="text-xs text-gray-600">
               {t('analytics.consent.privacyText')}
             </p>
           )}

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -20,11 +20,11 @@ const buttonVariants = cva(
           'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
         link: 'text-primary underline-offset-4 hover:underline',
         brand:
-          'rounded-[60px] bg-[#ff6000] text-white font-medium hover:bg-[#e55600]',
+          'rounded-[60px] bg-brand text-white font-medium hover:bg-orange-600',
         'brand-outline':
-          'rounded-[60px] border border-[#ff6000] bg-white text-[#ff6000] font-medium hover:bg-[#fff5ef]',
+          'rounded-[60px] border border-brand bg-white text-brand font-medium hover:bg-[#fff5ef]',
         'brand-disabled':
-          'rounded-[60px] bg-[#ccc] text-white font-medium cursor-not-allowed hover:bg-[#ccc]',
+          'rounded-[60px] bg-gray-200 text-white font-medium cursor-not-allowed hover:bg-gray-200',
       },
       size: {
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',

--- a/frontend/components/ui/chip.tsx
+++ b/frontend/components/ui/chip.tsx
@@ -12,14 +12,14 @@ type ChipProps = {
 };
 
 const VARIANT_CLASS: Record<ChipVariant, string> = {
-  displayed: 'border-[#b3b3b3]',
-  searched: 'border-[#b3b3b3] text-[#333] gap-[10px]',
-  selected: 'border-[#ff904c] text-[#333] gap-[10px]',
+  displayed: 'border-gray-300',
+  searched: 'border-gray-300 text-gray-800 gap-[10px]',
+  selected: 'border-orange-200 text-gray-800 gap-[10px]',
 };
 
 const SIZE_CLASS: Record<ChipSize, string> = {
-  sm: 'border-[0.5px] px-[8px] py-[6px] rounded-[5px] text-[14px] tracking-[-0.21px]',
-  md: 'border px-[10px] py-[8px] rounded-[8px] text-[16px]',
+  sm: 'border-[0.5px] px-[8px] py-[6px] rounded-[5px] text-caption-1',
+  md: 'border px-[10px] py-[8px] rounded-[8px] text-body-2',
 };
 
 export function Chip({
@@ -34,8 +34,8 @@ export function Chip({
   const displayedTextClass =
     variant === 'displayed'
       ? size === 'sm'
-        ? 'text-[#666]'
-        : 'text-[#4c4c4c]'
+        ? 'text-gray-600'
+        : 'text-gray-700'
       : '';
 
   return (

--- a/frontend/components/ui/date-picker.tsx
+++ b/frontend/components/ui/date-picker.tsx
@@ -47,10 +47,10 @@ function ScrollColumn({
         <button
           key={item}
           type="button"
-          className={`flex h-[41px] w-full items-center justify-center rounded-[5px] px-[10px] text-center text-[14px] font-medium tracking-[-0.21px] ${
+          className={`flex h-[41px] w-full items-center justify-center rounded-[5px] px-[10px] text-center text-caption-1 ${
             item === selected
               ? 'font-medium text-brand'
-              : 'text-[#333] hover:bg-brand-sub hover:text-brand'
+              : 'text-gray-800 hover:bg-brand-sub hover:text-brand'
           }`}
           onClick={() => onSelect(item)}
         >
@@ -121,13 +121,13 @@ export function DatePicker({
         type="button"
         className={`flex h-[52px] items-center justify-between rounded-[10px] px-[20px] text-left ${triggerWidthClass} ${
           hasValue
-            ? 'border border-gray-300 bg-white text-[#333]'
-            : 'bg-bg text-[#666]'
+            ? 'border border-gray-300 bg-white text-gray-800'
+            : 'bg-bg text-gray-600'
         }`}
         onClick={() => setOpen(!open)}
         aria-expanded={open}
       >
-        <span className="text-[14px] font-medium tracking-[-0.21px]">
+        <span className="text-caption-1">
           {hasValue ? formatDate(value, type) : placeholder}
         </span>
         {required && <Icon name="required" size={24} />}
@@ -163,7 +163,7 @@ export function DatePicker({
           <div className="mt-[10px] flex justify-end">
             <button
               type="button"
-              className="rounded-[60px] bg-brand px-[10px] py-[5px] text-center text-[16px] font-medium text-white"
+              className="rounded-[60px] bg-brand px-[10px] py-[5px] text-center text-body-2 text-white"
               onClick={handleSelect}
             >
               {t('datePicker.select')}

--- a/frontend/components/ui/dialcode-picker.tsx
+++ b/frontend/components/ui/dialcode-picker.tsx
@@ -32,7 +32,7 @@ export function DialcodePicker({ value, onChange }: DialcodePickerProps) {
     <div ref={ref} className="relative">
       <button
         type="button"
-        className="flex h-[44px] items-center gap-[5px] rounded-[10px] bg-[#fbfbfb] px-[15px] py-[10px]"
+        className="flex h-[44px] items-center gap-[5px] rounded-[10px] bg-bg px-[15px] py-[10px]"
         onClick={() => setOpen(!open)}
         aria-expanded={open}
       >
@@ -41,7 +41,7 @@ export function DialcodePicker({ value, onChange }: DialcodePickerProps) {
         ) : (
           <span className="h-[18px] w-[20px]" />
         )}
-        <span className="text-[14px] font-medium tracking-[-0.21px] text-[#666]">{value}</span>
+        <span className="text-caption-1 text-gray-600">{value}</span>
         <Icon name={open ? 'chevron-up' : 'chevron-down'} size={18} />
       </button>
       {open && (
@@ -57,7 +57,7 @@ export function DialcodePicker({ value, onChange }: DialcodePickerProps) {
               }}
             >
               <Icon name={option.flag} size={20} />
-              <span className="text-[14px] font-medium tracking-[-0.21px] text-[#666]">
+              <span className="text-caption-1 text-gray-600">
                 {option.code}
               </span>
             </button>

--- a/frontend/components/ui/form-dropdown.tsx
+++ b/frontend/components/ui/form-dropdown.tsx
@@ -23,7 +23,7 @@ function DropdownMenu({
   return (
     <button
       type="button"
-      className="w-full rounded-[5px] px-[20px] py-[10px] text-left text-[14px] font-medium tracking-[-0.21px] text-[#333] hover:bg-[#ffefe5] hover:text-[#ff6000]"
+      className="w-full rounded-[5px] px-[20px] py-[10px] text-left text-caption-1 text-gray-800 hover:bg-brand-sub hover:text-brand"
       onClick={onSelect}
     >
       {label}
@@ -76,8 +76,8 @@ export function FormDropdown({
 
   const triggerClass = `flex h-[52px] w-full items-center justify-between rounded-[10px] px-[20px] text-left ${
     hasValue
-      ? 'bg-white border border-[#b3b3b3] text-[#333]'
-      : 'bg-[#fbfbfb] text-[#666]'
+      ? 'bg-white border border-gray-300 text-gray-800'
+      : 'bg-bg text-gray-600'
   }`;
 
   return (
@@ -88,11 +88,7 @@ export function FormDropdown({
         onClick={() => setOpen(!open)}
         aria-expanded={open}
       >
-        <span
-          className={
-            hasValue ? 'text-[16px] font-medium' : 'text-[14px] font-medium tracking-[-0.21px]'
-          }
-        >
+        <span className={hasValue ? 'text-body-2' : 'text-caption-1'}>
           {selected ? selected.label : placeholder}
         </span>
         <span className="flex items-center gap-[4px]">

--- a/frontend/components/ui/form-input.tsx
+++ b/frontend/components/ui/form-input.tsx
@@ -22,7 +22,7 @@ const SIZE_CLASS: Record<FormInputSize, string> = {
 };
 
 const baseClass =
-  'w-full rounded-[10px] text-[16px] text-[#333] placeholder:text-[14px] placeholder:tracking-[-0.21px] placeholder:text-[#666] outline-none';
+  'w-full rounded-[10px] text-body-2 text-gray-800 placeholder:text-caption-1 placeholder:text-gray-600 outline-none';
 
 export const FormInput = forwardRef<
   HTMLInputElement | HTMLTextAreaElement,
@@ -48,17 +48,15 @@ export const FormInput = forwardRef<
 
     return (
       <span
-        className={`inline-flex h-[52px] w-full items-center justify-center gap-[5px] rounded-[10px] bg-[#fbfbfb] px-[20px] ${className ?? ''}`}
+        className={`inline-flex h-[52px] w-full items-center justify-center gap-[5px] rounded-[10px] bg-bg px-[20px] ${className ?? ''}`}
       >
         <Icon name="plus" size={24} />
-        <span className="text-[14px] font-medium tracking-[-0.21px] text-[#666]">{fileText}</span>
+        <span className="text-caption-1 text-gray-600">{fileText}</span>
       </span>
     );
   }
 
-  const stateClass = filled
-    ? 'bg-white border border-[#b3b3b3]'
-    : 'bg-[#fbfbfb]';
+  const stateClass = filled ? 'bg-white border border-gray-300' : 'bg-bg';
 
   const combinedClass = `${baseClass} ${SIZE_CLASS[size]} ${stateClass} ${className ?? ''}`;
 

--- a/frontend/components/ui/lang-picker.tsx
+++ b/frontend/components/ui/lang-picker.tsx
@@ -40,7 +40,7 @@ export function LangPicker({
       <button
         type="button"
         aria-label={ariaLabel ?? selected?.label ?? value}
-        className="flex h-[60px] w-[89px] items-center justify-center gap-[2px] rounded-[80px] bg-white px-[20px] py-[10px] text-[16px] font-medium text-black shadow-[0_0_15px_rgba(255,149,84,0.2)]"
+        className="flex h-[60px] w-[89px] items-center justify-center gap-[2px] rounded-[80px] bg-white px-[20px] py-[10px] text-body-2 text-black shadow-[0_0_15px_rgba(255,149,84,0.2)]"
         onClick={() => setOpen(!open)}
         aria-expanded={open}
       >
@@ -53,7 +53,7 @@ export function LangPicker({
             <button
               key={option.value}
               type="button"
-              className="flex w-full items-center justify-center px-[10px] py-[5px] text-[16px] font-medium text-black"
+              className="flex w-full items-center justify-center px-[10px] py-[5px] text-body-2 text-black"
               onClick={() => {
                 onChange(option.value);
                 setOpen(false);

--- a/frontend/components/ui/login-field.tsx
+++ b/frontend/components/ui/login-field.tsx
@@ -31,7 +31,7 @@ export const LoginField = forwardRef<HTMLInputElement, LoginFieldProps>(
     return (
       <div
         className={cn(
-          'flex h-[52px] w-full items-center justify-between overflow-hidden rounded-[10px] border border-[#b3b3b3] bg-white px-[20px] py-[10px]',
+          'flex h-[52px] w-full items-center justify-between overflow-hidden rounded-[10px] border border-gray-300 bg-white px-[20px] py-[10px]',
           className
         )}
       >
@@ -49,9 +49,9 @@ export const LoginField = forwardRef<HTMLInputElement, LoginFieldProps>(
             ref={ref}
             {...props}
             className={cn(
-              'w-full bg-transparent text-[16px] leading-[1.5] font-medium outline-none',
-              hasValue ? 'text-[#333]' : 'text-[#999]',
-              'placeholder:text-[16px] placeholder:leading-[1.5] placeholder:font-medium placeholder:text-[#999]'
+              'w-full bg-transparent text-body-2 outline-none',
+              hasValue ? 'text-gray-800' : 'text-gray-400',
+              'placeholder:text-body-2 placeholder:text-gray-400'
             )}
           />
         </div>

--- a/frontend/components/ui/numbered-pagination.tsx
+++ b/frontend/components/ui/numbered-pagination.tsx
@@ -69,14 +69,14 @@ export function NumberedPagination({
           p === '...' ? (
             <span
               key={`dots-${i}`}
-              className="text-[20px] leading-none text-black"
+              className="text-h3 leading-none font-normal text-black"
             >
               ···
             </span>
           ) : p === currentPage ? (
             <span
               key={p}
-              className="flex h-[24px] w-[24px] items-center justify-center rounded-[60px] bg-[#ffefe5] text-[20px] leading-none font-normal text-[#ff6000]"
+              className="flex h-[24px] w-[24px] items-center justify-center rounded-[60px] bg-brand-sub text-h3 leading-none font-normal text-brand"
             >
               {p}
             </span>
@@ -84,7 +84,7 @@ export function NumberedPagination({
             <Link
               key={p}
               href={buildHref(p)}
-              className="flex items-center justify-center text-[20px] leading-none font-normal text-black"
+              className="flex items-center justify-center text-h3 leading-none font-normal text-black"
             >
               {p}
             </Link>

--- a/frontend/components/ui/post-status.tsx
+++ b/frontend/components/ui/post-status.tsx
@@ -12,19 +12,19 @@ type PostStatusProps = {
 const CONFIG = {
   recruiting: {
     icon: 'status-recruiting',
-    color: 'text-[#00a600]',
+    color: 'text-success',
     defaultLabelKey: 'jobs.status.recruiting',
   },
   done: {
     icon: 'status-done',
-    color: 'text-[#e50000]',
+    color: 'text-error',
     defaultLabelKey: 'jobs.status.done',
   },
 } as const;
 
 const SIZE_CLASS = {
-  sm: 'text-[12px]',
-  md: 'text-[14px] tracking-[-0.21px]',
+  sm: 'text-caption-2',
+  md: 'text-caption-1',
 } as const;
 
 export function PostStatus({ status, size = 'sm', label }: PostStatusProps) {
@@ -35,9 +35,7 @@ export function PostStatus({ status, size = 'sm', label }: PostStatusProps) {
   return (
     <span className="inline-flex items-center justify-center gap-[2px]">
       <Icon name={config.icon} size={18} />
-      <span
-        className={`leading-[1.5] font-medium ${config.color} ${SIZE_CLASS[size]}`}
-      >
+      <span className={`${config.color} ${SIZE_CLASS[size]}`}>
         {displayLabel}
       </span>
     </span>

--- a/frontend/components/ui/search-bar.tsx
+++ b/frontend/components/ui/search-bar.tsx
@@ -8,8 +8,8 @@ type SearchBarProps = {
 };
 
 const VARIANT_CLASS = {
-  main: 'h-[50px] rounded-[60px] border border-[#b3b3b3] bg-white px-[20px]',
-  skills: 'h-[52px] rounded-[999px] bg-[#fbfbfb] px-[20px] pl-[54px]',
+  main: 'h-[50px] rounded-[60px] border border-gray-300 bg-white px-[20px]',
+  skills: 'h-[52px] rounded-[999px] bg-bg px-[20px] pl-[54px]',
 } as const;
 
 export function SearchBar({
@@ -31,11 +31,11 @@ export function SearchBar({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         className={[
-          'w-full bg-transparent outline-none placeholder:text-[#999]',
+          'w-full bg-transparent outline-none placeholder:text-gray-400',
           variant === 'skills'
-            ? 'text-[14px] leading-[1.5] font-bold tracking-[0.4354px]'
-            : 'text-[16px] leading-normal font-normal',
-          value ? 'text-[#333]' : 'text-[#999]',
+            ? 'text-caption-1 font-bold tracking-[0.4354px]'
+            : 'text-body-2 font-normal',
+          value ? 'text-gray-800' : 'text-gray-400',
           VARIANT_CLASS[variant],
         ].join(' ')}
       />

--- a/frontend/components/ui/section-title.tsx
+++ b/frontend/components/ui/section-title.tsx
@@ -9,7 +9,7 @@ export function SectionTitle({ title, onAdd }: SectionTitleProps) {
   return (
     <div className="flex flex-col gap-[10px]">
       <div className="flex min-h-[32px] items-center justify-between">
-        <h2 className="text-[22px] font-bold text-[#1a1a1a]">{title}</h2>
+        <h2 className="text-h2 text-gray-950">{title}</h2>
         {onAdd && (
           <button
             type="button"
@@ -20,7 +20,7 @@ export function SectionTitle({ title, onAdd }: SectionTitleProps) {
           </button>
         )}
       </div>
-      <div className="h-px w-full bg-[#b3b3b3]" />
+      <div className="h-px w-full bg-gray-300" />
     </div>
   );
 }

--- a/frontend/components/ui/social-ls.tsx
+++ b/frontend/components/ui/social-ls.tsx
@@ -42,7 +42,7 @@ export function SocialLs({
     <button
       type="button"
       className={cn(
-        'flex h-[52px] w-full items-center justify-center gap-[10px] overflow-hidden rounded-[10px] border border-[#b3b3b3] bg-white px-[90px] py-[20px] text-[#333]',
+        'flex h-[52px] w-full items-center justify-center gap-[10px] overflow-hidden rounded-[10px] border border-gray-300 bg-white px-[90px] py-[20px] text-gray-800',
         className
       )}
       {...props}
@@ -54,9 +54,7 @@ export function SocialLs({
       ) : (
         <Icon name={meta.iconName} size={meta.iconSize} alt={provider} />
       )}
-      <span className="text-center text-[16px] leading-[1.5] font-medium text-[#333]">
-        {label}
-      </span>
+      <span className="text-center text-body-2 text-gray-800">{label}</span>
     </button>
   );
 }

--- a/frontend/components/ui/tab-item.tsx
+++ b/frontend/components/ui/tab-item.tsx
@@ -13,10 +13,10 @@ export function TabItem({ label, isActive, href, onClick }: TabItemProps) {
     <Link
       href={href}
       onClick={onClick}
-      className={`inline-flex items-center justify-center border-b px-[10px] py-[5px] text-[16px] leading-[1.5] font-medium transition-colors ${
+      className={`inline-flex items-center justify-center border-b px-[10px] py-[5px] text-body-2 transition-colors ${
         isActive
           ? 'border-brand font-bold text-brand'
-          : 'border-gray-100 text-[#333] hover:rounded-[130px] hover:bg-brand-sub hover:text-[#1a1a1a]'
+          : 'border-gray-100 text-gray-800 hover:rounded-[130px] hover:bg-brand-sub hover:text-gray-950'
       }`}
     >
       {label}

--- a/frontend/components/ui/toggle-switch.tsx
+++ b/frontend/components/ui/toggle-switch.tsx
@@ -36,7 +36,7 @@ export function ToggleSwitch({
       aria-checked={checked}
       onClick={() => onChange(!checked)}
       className={`relative rounded-[999px] transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-[#ff6000]/40 ${config.track} ${
-        checked ? 'bg-[#00a600]' : 'bg-[#e6e6e6]'
+        checked ? 'bg-success' : 'bg-gray-100'
       }`}
     >
       <span

--- a/frontend/entities/job/ui/posting-list-item.tsx
+++ b/frontend/entities/job/ui/posting-list-item.tsx
@@ -53,16 +53,16 @@ export function PostingListItem({
 
   return (
     <Link href={href} className="block">
-      <div className="rounded-[20px] border border-[#ffefe5] bg-white px-[40px] py-[20px]">
+      <div className="rounded-[20px] border border-brand-sub bg-white px-[40px] py-[20px]">
         <div className="flex items-center gap-[20px]">
           <div className="flex shrink-0 items-center gap-[10px]">
-            <div className="h-[40px] w-[40px] bg-[#eee]" />
+            <div className="h-[40px] w-[40px] bg-gray-100" />
             <div className="flex flex-col justify-center">
-              <span className="text-[16px] font-medium text-[#333]">
+              <span className="text-body-2 text-gray-800">
                 {orgName ?? '-'}
               </span>
               <div className="flex items-start gap-[5px]">
-                <span className="text-[12px] text-[#808080]">
+                <span className="text-caption-2 text-gray-500">
                   {formatDate(createdAt, locale)}
                 </span>
                 <PostStatus status={status} size="sm" />
@@ -72,9 +72,9 @@ export function PostingListItem({
 
           <div className="flex min-w-0 flex-1 items-center gap-[10px]">
             <div className="flex min-w-0 flex-1 flex-col gap-[20px] rounded-[20px] p-[20px]">
-              <h3 className="text-[20px] font-bold text-black">{title}</h3>
+              <h3 className="text-h3 text-black">{title}</h3>
 
-              <div className="flex flex-wrap items-center gap-[20px] text-[16px] text-[#333]">
+              <div className="flex flex-wrap items-center gap-[20px] text-body-2 text-gray-800">
                 <span className="inline-flex items-center gap-[5px]">
                   <Icon name="jobs" size={24} />
                   {jobDisplayName}

--- a/frontend/entities/job/ui/posting-title.tsx
+++ b/frontend/entities/job/ui/posting-title.tsx
@@ -67,13 +67,11 @@ export function PostingTitle({
       </div>
 
       <div className="flex min-w-0 flex-1 items-center gap-[20px]">
-        <div className="h-[97px] w-[97px] shrink-0 bg-[#ff6000]" />
+        <div className="h-[97px] w-[97px] shrink-0 bg-brand" />
         <div className="flex min-w-0 flex-1 flex-col gap-[10px]">
-          <h1 className="truncate text-[30px] font-bold text-black">
-            {displayTitle}
-          </h1>
+          <h1 className="truncate text-title text-black">{displayTitle}</h1>
           <div className="flex items-center gap-[5px]">
-            <span className="text-[14px] text-[#808080]">
+            <span className="text-caption-1 text-gray-500">
               {formatDate(createdAt, locale)}
             </span>
             <PostStatus status={status} size="md" />

--- a/frontend/entities/job/ui/summary-card.tsx
+++ b/frontend/entities/job/ui/summary-card.tsx
@@ -43,10 +43,10 @@ export function SummaryCard({
     : getEmploymentTypeLabel(employmentType, t);
 
   return (
-    <div className="w-[300px] rounded-[20px] border border-[#b3b3b3] bg-white px-[20px] py-[40px]">
+    <div className="w-[300px] rounded-[20px] border border-gray-300 bg-white px-[20px] py-[40px]">
       <div className="flex flex-col gap-[40px]">
         <div className="flex flex-col gap-[20px]">
-          <div className="flex flex-col gap-[10px] text-[18px] text-[#333]">
+          <div className="flex flex-col gap-[10px] text-body-1 text-gray-800">
             <span className="inline-flex items-center gap-[10px]">
               <Icon name="jobs" size={24} />
               {jobDisplayName}
@@ -96,7 +96,7 @@ export function SummaryCard({
             <button
               type="button"
               aria-label={t('jobs.apply')}
-              className="inline-flex h-[60px] w-[60px] items-center justify-center rounded-full border border-[#ff6000] bg-white text-[#ff6000]"
+              className="inline-flex h-[60px] w-[60px] items-center justify-center rounded-full border border-brand bg-white text-brand"
             >
               <Icon name="chevron-right" size={24} />
             </button>

--- a/frontend/entities/profile/ui/profile-card.tsx
+++ b/frontend/entities/profile/ui/profile-card.tsx
@@ -61,20 +61,18 @@ export function ProfileCard({
   return (
     <div
       className={[
-        'rounded-[20px] bg-[#fbfbfb] px-[40px]',
+        'rounded-[20px] bg-bg px-[40px]',
         isMyProfile
           ? 'flex flex-col gap-[25px] pt-[20px] pb-[40px]'
           : 'py-[20px]',
       ].join(' ')}
     >
       {isMyProfile && (
-        <h2 className="text-[22px] leading-[1.5] font-bold text-[#1a1a1a]">
-          {t('profile.basicProfile')}
-        </h2>
+        <h2 className="text-h2 text-gray-950">{t('profile.basicProfile')}</h2>
       )}
       <div className="flex items-center gap-[25px]">
         <div className="flex flex-col items-center gap-[10px]">
-          <div className="flex h-[200px] w-[200px] items-center justify-center overflow-hidden rounded-full bg-[#e6e6e6]">
+          <div className="flex h-[200px] w-[200px] items-center justify-center overflow-hidden rounded-full bg-gray-100">
             {profileImageUrl ? (
               <Image
                 src={profileImageUrl}
@@ -106,17 +104,17 @@ export function ProfileCard({
 
         <div className="flex min-w-0 flex-1 flex-col gap-[20px]">
           <div className="flex flex-col pb-px">
-            <h2 className="text-[30px] leading-[1.5] font-bold text-[#1a1a1a]">
+            <h2 className="text-title text-gray-950">
               {firstName} {lastName}
             </h2>
             {dateOfBirth && (
-              <span className="text-[16px] leading-[1.5] font-medium text-[#666]">
+              <span className="text-body-2 text-gray-600">
                 {formatDob(dateOfBirth, locale)}
               </span>
             )}
           </div>
 
-          <div className="flex flex-col gap-[6px] text-[16px] leading-[1.5] font-medium text-[#333]">
+          <div className="flex flex-col gap-[6px] text-body-2 text-gray-800">
             <div className="flex flex-wrap items-center gap-[25px]">
               {phone && (
                 <span className="inline-flex items-center gap-[4px]">
@@ -140,9 +138,7 @@ export function ProfileCard({
           </div>
 
           <div className="rounded-[10px] bg-white p-[20px]">
-            <p className="text-[18px] leading-[1.5] font-medium text-[#333]">
-              {summary ?? ''}
-            </p>
+            <p className="text-body-1 text-gray-800">{summary ?? ''}</p>
           </div>
         </div>
       </div>

--- a/frontend/features/auth/ui/login-modal.tsx
+++ b/frontend/features/auth/ui/login-modal.tsx
@@ -112,7 +112,7 @@ export function LoginModal() {
       >
         <div className="flex flex-col items-center gap-10 px-5 pt-5 pb-20">
           <div className="flex w-full items-center justify-between">
-            <p className="text-sm text-[#666]">
+            <p className="text-sm text-gray-600">
               {t('auth.login.noAccount')}{' '}
               <button
                 type="button"
@@ -136,14 +136,14 @@ export function LoginModal() {
               type="button"
               onClick={closeAll}
               aria-label={t('auth.login.closeAria')}
-              className="rounded-sm p-1 text-[#1a1a1a] hover:bg-[#f5f5f5]"
+              className="rounded-sm p-1 text-gray-950 hover:bg-[#f5f5f5]"
             >
               <Icon name="close" size={16} />
             </button>
           </div>
 
           <div className="flex w-full max-w-[520px] flex-col items-center gap-10">
-            <DialogTitle className="text-[26px] leading-[1.5] font-bold text-[#313131]">
+            <DialogTitle className="text-h1 text-gray-950">
               {t('auth.login.title')}
             </DialogTitle>
             <DialogDescription className="sr-only">
@@ -190,11 +190,11 @@ export function LoginModal() {
             </div>
 
             <div className="flex w-full items-center gap-2.5 overflow-hidden">
-              <div className="h-px flex-1 bg-[#b3b3b3]" />
-              <span className="text-sm font-medium text-[#999]">
+              <div className="h-px flex-1 bg-gray-300" />
+              <span className="text-sm font-medium text-gray-400">
                 {t('common.or')}
               </span>
-              <div className="h-px flex-1 bg-[#b3b3b3]" />
+              <div className="h-px flex-1 bg-gray-300" />
             </div>
 
             <form
@@ -271,7 +271,7 @@ export function LoginModal() {
                           )}
                       </div>
                       {serverError && (
-                        <p className="flex items-center text-sm leading-[1.5] font-medium text-[#e50000]">
+                        <p className="flex items-center text-sm leading-[1.5] font-medium text-error">
                           <Icon
                             name="error"
                             size={24}
@@ -282,7 +282,7 @@ export function LoginModal() {
                       )}
                       <button
                         type="button"
-                        className="text-right text-sm font-medium text-[#666] hover:underline"
+                        className="text-right text-sm font-medium text-gray-600 hover:underline"
                       >
                         {t('auth.login.forgotPassword')}
                       </button>

--- a/frontend/features/auth/ui/signup-modal.tsx
+++ b/frontend/features/auth/ui/signup-modal.tsx
@@ -160,7 +160,7 @@ export function SignupModal() {
         >
           {step !== 'success' && (
             <div className="flex w-full items-center justify-between">
-              <p className="text-sm text-[#666]">
+              <p className="text-sm text-gray-600">
                 {t('auth.signup.haveAccount')}{' '}
                 <button
                   type="button"
@@ -184,7 +184,7 @@ export function SignupModal() {
                 type="button"
                 onClick={closeAll}
                 aria-label={t('auth.signup.closeAria')}
-                className="rounded-sm p-1 text-[#1a1a1a] hover:bg-[#f5f5f5]"
+                className="rounded-sm p-1 text-gray-950 hover:bg-[#f5f5f5]"
               >
                 <Icon name="close" size={16} />
               </button>
@@ -197,7 +197,7 @@ export function SignupModal() {
             </DialogDescription>
             {step === 'method' && (
               <>
-                <DialogTitle className="text-[26px] leading-[1.5] font-bold text-[#313131]">
+                <DialogTitle className="text-h1 text-gray-950">
                   {t('auth.signup.title')}
                 </DialogTitle>
 
@@ -242,11 +242,11 @@ export function SignupModal() {
                 </div>
 
                 <div className="flex w-full items-center gap-2.5 overflow-hidden">
-                  <div className="h-px flex-1 bg-[#b3b3b3]" />
-                  <span className="text-sm font-medium text-[#999]">
+                  <div className="h-px flex-1 bg-gray-300" />
+                  <span className="text-sm font-medium text-gray-400">
                     {t('common.or')}
                   </span>
-                  <div className="h-px flex-1 bg-[#b3b3b3]" />
+                  <div className="h-px flex-1 bg-gray-300" />
                 </div>
 
                 <SocialLs
@@ -269,7 +269,7 @@ export function SignupModal() {
 
             {step === 'form' && (
               <>
-                <DialogTitle className="text-[26px] leading-[1.5] font-bold text-[#313131]">
+                <DialogTitle className="text-h1 text-gray-950">
                   {t('auth.signup.title')}
                 </DialogTitle>
 
@@ -321,7 +321,7 @@ export function SignupModal() {
                               )}
                           </div>
                           {emailError && (
-                            <p className="flex items-center text-sm leading-[1.5] font-medium text-[#e50000]">
+                            <p className="flex items-center text-sm leading-[1.5] font-medium text-error">
                               <Icon
                                 name="error"
                                 size={24}
@@ -369,9 +369,7 @@ export function SignupModal() {
                               <p
                                 className={cn(
                                   'flex items-center text-sm leading-[1.5] font-medium',
-                                  passwordValid
-                                    ? 'text-[#00a600]'
-                                    : 'text-[#e50000]'
+                                  passwordValid ? 'text-success' : 'text-error'
                                 )}
                               >
                                 <Icon
@@ -395,7 +393,7 @@ export function SignupModal() {
                   </div>
 
                   <div className="flex w-full flex-col gap-[10px]">
-                    <label className="flex h-[24px] w-full cursor-pointer items-center gap-[5px] text-sm leading-[1.5] font-medium text-[#666]">
+                    <label className="flex h-[24px] w-full cursor-pointer items-center gap-[5px] text-sm leading-[1.5] font-medium text-gray-600">
                       <input
                         type="checkbox"
                         className="sr-only"
@@ -415,7 +413,7 @@ export function SignupModal() {
                     </label>
 
                     {formError && (
-                      <p className="flex items-center text-sm leading-[1.5] font-medium text-[#e50000]">
+                      <p className="flex items-center text-sm leading-[1.5] font-medium text-error">
                         <Icon
                           name="error"
                           size={24}
@@ -464,7 +462,7 @@ export function SignupModal() {
             {step === 'success' && (
               <div className="flex w-full flex-col items-center gap-10">
                 <div className="flex flex-col items-center gap-5">
-                  <div className="flex size-[150px] items-center justify-center rounded-full bg-[#ff6000]">
+                  <div className="flex size-[150px] items-center justify-center rounded-full bg-brand">
                     <span
                       aria-hidden
                       className="text-[72px] leading-none font-bold text-white"
@@ -472,11 +470,11 @@ export function SignupModal() {
                       ✓
                     </span>
                   </div>
-                  <DialogTitle className="text-[22px] leading-[1.5] font-bold text-black">
+                  <DialogTitle className="text-h2 text-black">
                     {t('auth.signup.successTitle')}
                   </DialogTitle>
                 </div>
-                <p className="text-center text-[20px] leading-[1.5] font-medium text-[#666]">
+                <p className="text-center text-h4 text-gray-600">
                   {t('auth.signup.successDescription')}
                 </p>
                 <Button

--- a/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
+++ b/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
@@ -192,7 +192,7 @@ const EMPTY_URL: Omit<DraftUrl, 'id'> = {
 };
 
 const BASE_SECTION_CLASS = 'w-full rounded-[20px] px-[40px] py-[20px]';
-const BASIC_SECTION_CLASS = `${BASE_SECTION_CLASS} border-2 border-[#ffefe5] bg-white`;
+const BASIC_SECTION_CLASS = `${BASE_SECTION_CLASS} border-2 border-brand-sub bg-white`;
 
 const CORE_EDUCATION_ORDER = [
   'vet_elementary',
@@ -223,9 +223,7 @@ function SectionHeader({
   return (
     <div className="flex flex-col gap-[10px]">
       <div className="flex items-start justify-between">
-        <h2 className="text-[22px] leading-[1.5] font-bold text-[#1a1a1a]">
-          {title}
-        </h2>
+        <h2 className="text-h2 text-gray-950">{title}</h2>
         {onAdd && (
           <button
             type="button"
@@ -233,11 +231,11 @@ function SectionHeader({
             className="flex size-[42px] items-center justify-center"
             aria-label={addAriaLabel ?? title}
           >
-            <span className="text-[30px] leading-[1.5] text-[#1a1a1a]">+</span>
+            <span className="text-title text-gray-950">+</span>
           </button>
         )}
       </div>
-      <div className="h-px w-full bg-[#e6e6e6]" />
+      <div className="h-px w-full bg-gray-100" />
     </div>
   );
 }
@@ -702,13 +700,11 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
     <>
       <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-[40px] px-6 py-10 pb-[140px]">
         <section className={BASIC_SECTION_CLASS}>
-          <h2 className="text-[22px] leading-[1.5] font-bold text-[#1a1a1a]">
-            {t('profile.basicProfile')}
-          </h2>
+          <h2 className="text-h2 text-gray-950">{t('profile.basicProfile')}</h2>
 
           <div className="mt-[25px] flex flex-col gap-6 lg:flex-row lg:items-start">
             <div className="flex flex-col items-center gap-4">
-              <div className="flex h-48 w-48 items-center justify-center rounded-full bg-[#ffefe5]">
+              <div className="flex h-48 w-48 items-center justify-center rounded-full bg-brand-sub">
                 <Icon
                   name="profile"
                   size={96}
@@ -716,7 +712,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                 />
               </div>
               <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-[#1a1a1a]">
+                <span className="text-sm font-medium text-gray-950">
                   {t('profile.hiringStatus')}
                 </span>
                 <ToggleSwitch
@@ -751,7 +747,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
               </div>
 
               <div className="flex items-center gap-3">
-                <span className="text-sm font-medium text-[#1a1a1a]">
+                <span className="text-sm font-medium text-gray-950">
                   {t('form.dateOfBirth')}
                 </span>
                 <DatePicker
@@ -774,7 +770,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
               </div>
 
               <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
-                <div className="flex items-center gap-2 rounded-[10px] bg-[#fbfbfb] px-3 py-2">
+                <div className="flex items-center gap-2 rounded-[10px] bg-bg px-3 py-2">
                   <Icon name="mobile" size={20} />
                   <DialcodePicker
                     value={draft.contact.dialCode}
@@ -792,7 +788,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                   />
                 </div>
 
-                <div className="flex items-center gap-2 rounded-[10px] bg-[#fbfbfb] px-3 py-2">
+                <div className="flex items-center gap-2 rounded-[10px] bg-bg px-3 py-2">
                   <Icon name="mail" size={20} />
                   <FormInput
                     className="h-11 bg-transparent"
@@ -805,7 +801,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                 </div>
               </div>
 
-              <div className="flex items-center gap-2 rounded-[10px] bg-[#fbfbfb] px-3 py-2">
+              <div className="flex items-center gap-2 rounded-[10px] bg-bg px-3 py-2">
                 <Icon name="location" size={20} />
                 <FormInput
                   required
@@ -1197,7 +1193,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                   >
-                    <SelectTrigger className="h-[52px] rounded-[10px] bg-[#fbfbfb]">
+                    <SelectTrigger className="h-[52px] rounded-[10px] bg-bg">
                       <SelectValue placeholder={t('form.field')} />
                     </SelectTrigger>
                     <SelectContent>
@@ -1527,18 +1523,16 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
           <div className="mt-[25px] flex flex-col gap-[25px]">
             <button
               type="button"
-              className="flex h-[52px] w-full items-center justify-center gap-1 rounded-[10px] bg-[#f8f8f8] px-[20px] text-[14px] font-medium text-[#666]"
+              className="flex h-[52px] w-full items-center justify-center gap-1 rounded-[10px] bg-[#f8f8f8] px-[20px] text-caption-1 text-gray-600"
             >
               <Icon name="plus" size={16} />
               {t('profile.upload.file')}
             </button>
             <div className="flex items-center justify-between">
-              <p className="text-[18px] leading-[1.5] font-medium text-[#333]">
+              <p className="text-body-1 text-gray-800">
                 {t('profile.upload.uploadedFile')}
               </p>
-              <p className="text-[16px] leading-[1.5] font-medium text-[#808080]">
-                -
-              </p>
+              <p className="text-body-2 text-gray-500">-</p>
             </div>
           </div>
         </section>

--- a/frontend/features/profile-edit/ui/profile-public-form.tsx
+++ b/frontend/features/profile-edit/ui/profile-public-form.tsx
@@ -195,8 +195,8 @@ export function ProfilePublicForm({ initialData }: Props) {
 
       <form.Field name="isOpenToWork">
         {(field) => (
-          <div className="flex items-center justify-between rounded-[10px] bg-[#fbfbfb] px-[20px] py-[12px]">
-            <span className="text-sm text-[#333]">
+          <div className="flex items-center justify-between rounded-[10px] bg-bg px-[20px] py-[12px]">
+            <span className="text-sm text-gray-800">
               {t('profile.openToWork')}
             </span>
             <ToggleSwitch

--- a/frontend/widgets/nav/ui/main-nav.tsx
+++ b/frontend/widgets/nav/ui/main-nav.tsx
@@ -76,8 +76,8 @@ export default function MainNav() {
                 key={href}
                 href={href}
                 className={[
-                  'text-[22px] leading-[1.5] font-bold transition-colors',
-                  isActive ? 'text-brand' : 'text-[#1a1a1a] hover:text-brand',
+                  'text-h2 transition-colors',
+                  isActive ? 'text-brand' : 'text-gray-950 hover:text-brand',
                 ].join(' ')}
               >
                 {label}
@@ -105,15 +105,15 @@ export default function MainNav() {
             <button
               type="button"
               onClick={handleOpenLogin}
-              className="text-[18px] leading-[1.5] font-medium text-[#1a1a1a] hover:text-brand"
+              className="text-body-1 text-gray-950 hover:text-brand"
             >
               {t('nav.login')}
             </button>
-            <span className="mx-[10px] h-[16px] w-px bg-[#b3b3b3]" />
+            <span className="mx-[10px] h-[16px] w-px bg-gray-300" />
             <button
               type="button"
               onClick={handleOpenSignup}
-              className="text-[18px] leading-[1.5] font-medium text-[#1a1a1a] hover:text-brand"
+              className="text-body-1 text-gray-950 hover:text-brand"
             >
               {t('nav.signup')}
             </button>


### PR DESCRIPTION
## 🔥 PR 제목

> refactor + 프론트엔드 컴포넌트의 임의 CSS 값을 Tailwind v4 디자인 토큰 클래스로 전면 교체

Closes #69

## ✨ 작업 내용

- `globals.css` `@theme`에 `--text-h1` ~ `--text-h4` 타이포그래피 토큰 추가 (기존 `@layer base` 우회책 제거)
- 26개 컴포넌트 파일의 임의 색상(`text-[#1a1a1a]`, `bg-[#fbfbfb]` 등) → 토큰 클래스(`text-gray-950`, `bg-bg` 등)로 교체
- 26개 컴포넌트 파일의 임의 타이포그래피(`text-[22px] font-bold`, `text-[16px] font-medium` 등) → 토큰 클래스(`text-h2`, `text-body-2` 등)로 교체, 토큰에 포함된 중복 `leading-*`/`font-*` 클래스 제거
- 13개 테스트 파일 클래스 어서션 업데이트

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

`pnpm test` 실행 시 542개 전체 통과 확인

## 📸 스크린샷 / 시연 (선택)

N/A — 시각적 변경 없음 (토큰 클래스로 교체만 진행, 실제 렌더링 동일)

## 🙏 리뷰어에게 한마디

토큰 기본 weight와 다른 경우(예: `text-h3 font-normal`, `font-bold` 오버라이드)는 명시적 weight 클래스를 유지했습니다. 예외 항목(`text-[32px]` 로고, `text-[72px]` 성공 아이콘 등)은 토큰이 없어 임의값 그대로 유지했습니다.