### PR TITLE
refactor(ui): 하드코딩 Tailwind 텍스트/색상 토큰 치환

### DIFF
--- a/__tests__/app/announcement-detail-page.test.tsx
+++ b/__tests__/app/announcement-detail-page.test.tsx
@@ -91,14 +91,14 @@ describe('AnnouncementDetailPage', () => {
       level: 1,
     });
     expect(heading).toBeInTheDocument();
-    expect(heading).toHaveClass('text-[30px]', 'leading-[1.5]');
+    expect(heading).toHaveClass('text-title', 'text-text-title-1');
     expect(screen.getByText('(Pinned)')).toBeInTheDocument();
 
     const markdownText = screen.getByText(/## About Us/);
     const markdownWrapper = markdownText.closest('div')?.parentElement;
     expect(markdownWrapper).toHaveClass(
-      'text-[18px]',
-      '[&_h2]:text-[22px]',
+      'text-body-1',
+      '[&_h2]:text-h2',
       '[&_ul]:list-disc',
       '[&_ul]:pl-[27px]',
       '[&_li]:mb-[4px]'
@@ -106,7 +106,7 @@ describe('AnnouncementDetailPage', () => {
 
     const contentCard = markdownWrapper?.parentElement;
     expect(contentCard).toHaveClass(
-      'bg-[#fbfbfb]',
+      'bg-bg',
       'rounded-[20px]',
       'px-[20px]',
       'pt-[20px]',
@@ -124,7 +124,7 @@ describe('AnnouncementDetailPage', () => {
     expect(screen.getByText('Next').parentElement).toHaveClass(
       'grid-cols-[94px_1fr_193px]',
       'gap-[30px]',
-      'text-[#4c4c4c]'
+      'text-text-body-2'
     );
     expect(
       screen.getByRole('link', { name: /back to announcement list/i })

--- a/__tests__/app/candidate-applications-page.test.tsx
+++ b/__tests__/app/candidate-applications-page.test.tsx
@@ -163,20 +163,20 @@ describe('MyApplicationsPage', () => {
       name: 'My Jobs',
       level: 1,
     });
-    expect(jobsHeading).toHaveClass('text-[26px]');
+    expect(jobsHeading).toHaveClass('text-h1');
 
     const listHeading = screen.getByRole('heading', {
       name: 'List',
       level: 2,
     });
-    expect(listHeading).toHaveClass('text-[26px]');
+    expect(listHeading).toHaveClass('text-h1');
 
     const appliedCard = screen.getByText('Applied').parentElement;
     const inProgressCard = screen.getByText('In progress').parentElement;
 
     expect(appliedCard).toHaveClass('rounded-[20px]');
-    expect(appliedCard).toHaveClass('bg-[#fbfbfb]');
+    expect(appliedCard).toHaveClass('bg-bg');
     expect(inProgressCard).toHaveClass('rounded-[20px]');
-    expect(inProgressCard).toHaveClass('bg-[#fbfbfb]');
+    expect(inProgressCard).toHaveClass('bg-bg');
   });
 });

--- a/__tests__/app/dashboard-sidebar.test.tsx
+++ b/__tests__/app/dashboard-sidebar.test.tsx
@@ -44,7 +44,7 @@ describe('DashboardSidebar', () => {
     const inactive = screen.getByRole('link', { name: 'My Jobs' });
 
     expect(active.className).toContain('text-brand');
-    expect(inactive.className).toContain('text-[#666]');
+    expect(inactive.className).toContain('text-text-sub-1');
   });
 
   it('Logout 클릭 시 signOut을 호출한다', () => {

--- a/__tests__/app/job-detail-page.test.tsx
+++ b/__tests__/app/job-detail-page.test.tsx
@@ -160,15 +160,16 @@ describe('JobDetailPage', () => {
     const markdownText = screen.getByText(/## About Us/);
     const markdownWrapper = markdownText.closest('div')?.parentElement;
     expect(markdownWrapper).toHaveClass(
-      'text-[18px]',
-      '[&_h2]:text-[22px]',
+      'text-body-1',
+      '[&_h2]:text-h2',
+      '[&_h2]:text-text-title-2',
       '[&_ul]:list-disc',
       '[&_ul]:pl-[27px]',
       '[&_li]:mb-[4px]'
     );
     const markdownCard = markdownWrapper?.parentElement;
     expect(markdownCard).toHaveClass(
-      'bg-[#fbfbfb]',
+      'bg-bg',
       'rounded-[20px]',
       'px-[40px]',
       'pt-[20px]',

--- a/__tests__/components/ui/button-brand.test.tsx
+++ b/__tests__/components/ui/button-brand.test.tsx
@@ -45,9 +45,7 @@ describe('Button brand variants', () => {
       expect(btn).toHaveClass('h-[34px]');
       expect(btn).toHaveClass('px-[10px]');
       expect(btn).toHaveClass('py-[5px]');
-      expect(btn).toHaveClass(
-        'text-[length:var(--typography-body-3-font-size)]'
-      );
+      expect(btn).toHaveClass('text-body-3');
       expect(btn).toHaveClass('gap-[5px]');
     });
 
@@ -61,9 +59,7 @@ describe('Button brand variants', () => {
       expect(btn).toHaveClass('h-[45px]');
       expect(btn).toHaveClass('px-[20px]');
       expect(btn).toHaveClass('py-[5px]');
-      expect(btn).toHaveClass(
-        'text-[length:var(--typography-body-3-font-size)]'
-      );
+      expect(btn).toHaveClass('text-body-3');
       expect(btn).toHaveClass('gap-[5px]');
     });
 
@@ -77,9 +73,7 @@ describe('Button brand variants', () => {
       expect(btn).toHaveClass('h-[54px]');
       expect(btn).toHaveClass('px-[40px]');
       expect(btn).toHaveClass('py-[15px]');
-      expect(btn).toHaveClass(
-        'text-[length:var(--typography-body-2-font-size)]'
-      );
+      expect(btn).toHaveClass('text-body-2');
       expect(btn).toHaveClass('font-bold');
       expect(btn).toHaveClass('gap-[5px]');
     });

--- a/app/(dashboard)/candidate/applications/loading.tsx
+++ b/app/(dashboard)/candidate/applications/loading.tsx
@@ -6,8 +6,8 @@ export default function CandidateApplicationsLoading() {
       <Skeleton className="h-10 w-48" />
 
       <div className="grid grid-cols-1 gap-[10px] md:grid-cols-2">
-        <Skeleton className="h-[166px] rounded-[20px] bg-[#fbfbfb]" />
-        <Skeleton className="h-[166px] rounded-[20px] bg-[#fbfbfb]" />
+        <Skeleton className="h-[166px] rounded-[20px] bg-bg" />
+        <Skeleton className="h-[166px] rounded-[20px] bg-bg" />
       </div>
 
       <div className="flex flex-col gap-[20px] rounded-[20px] bg-white py-[20px]">
@@ -16,7 +16,7 @@ export default function CandidateApplicationsLoading() {
           {Array.from({ length: 3 }).map((_, index) => (
             <div
               key={`candidate-applications-loading-item-${index}`}
-              className="rounded-[20px] border border-[#ffefe5] bg-white px-[40px] py-[20px]"
+              className="rounded-[20px] border border-brand-sub bg-white px-[40px] py-[20px]"
             >
               <div className="flex items-start gap-4">
                 <Skeleton className="h-[40px] w-[40px]" />

--- a/app/(dashboard)/candidate/applications/page.tsx
+++ b/app/(dashboard)/candidate/applications/page.tsx
@@ -31,33 +31,21 @@ export default async function MyApplicationsPage() {
 
   return (
     <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-[20px]">
-      <h1 className="text-[26px] leading-[1.5] font-bold text-[#1f1d1b]">
-        {t('profile.myJobs')}
-      </h1>
+      <h1 className="text-h1 text-text-title-2">{t('profile.myJobs')}</h1>
 
       <div className="grid grid-cols-1 gap-[10px] md:grid-cols-2">
-        <div className="flex flex-col items-center justify-center gap-[10px] rounded-[20px] bg-[#fbfbfb] px-[40px] py-[50px] text-center">
-          <p className="text-[22px] leading-[1.5] font-bold text-[#1a1a1a]">
-            {t('profile.applied')}
-          </p>
-          <p className="text-[22px] leading-[1.5] font-bold text-[#1a1a1a]">
-            {appliedCount}
-          </p>
+        <div className="flex flex-col items-center justify-center gap-[10px] rounded-[20px] bg-bg px-[40px] py-[50px] text-center">
+          <p className="text-h2 text-text-title-2">{t('profile.applied')}</p>
+          <p className="text-h2 text-text-title-2">{appliedCount}</p>
         </div>
-        <div className="flex flex-col items-center justify-center gap-[10px] rounded-[20px] bg-[#fbfbfb] px-[40px] py-[50px] text-center">
-          <p className="text-[22px] leading-[1.5] font-bold text-[#1a1a1a]">
-            {t('profile.inProgress')}
-          </p>
-          <p className="text-[22px] leading-[1.5] font-bold text-[#1a1a1a]">
-            {inProgressCount}
-          </p>
+        <div className="flex flex-col items-center justify-center gap-[10px] rounded-[20px] bg-bg px-[40px] py-[50px] text-center">
+          <p className="text-h2 text-text-title-2">{t('profile.inProgress')}</p>
+          <p className="text-h2 text-text-title-2">{inProgressCount}</p>
         </div>
       </div>
 
       <section className="flex flex-col gap-[20px] rounded-[20px] bg-white py-[20px]">
-        <h2 className="text-[26px] leading-[1.5] font-bold text-[#1f1d1b]">
-          {t('profile.list')}
-        </h2>
+        <h2 className="text-h1 text-text-title-2">{t('profile.list')}</h2>
 
         {applications.length === 0 ? (
           <p className="text-muted-foreground">{t('jobs.empty')}</p>

--- a/app/(dashboard)/candidate/profile/profile-content.tsx
+++ b/app/(dashboard)/candidate/profile/profile-content.tsx
@@ -94,7 +94,7 @@ type Props = {
   t: Translator;
 };
 
-const CARD_CLASS = 'rounded-[20px] bg-[#fbfbfb] px-[40px] pt-[20px] pb-[40px]';
+const CARD_CLASS = 'rounded-[20px] bg-bg px-[40px] pt-[20px] pb-[40px]';
 
 function normalizeText(value?: string | null) {
   const text = value?.trim();
@@ -157,12 +157,12 @@ function resolvePortfolioLabel(item: Url) {
 }
 
 function Divider() {
-  return <span aria-hidden className="h-[10px] w-px bg-[#808080]" />;
+  return <span aria-hidden className="h-[10px] w-px bg-text-sub-2" />;
 }
 
 function ContactItem({ iconName, text }: { iconName: string; text: string }) {
   return (
-    <span className="inline-flex items-center gap-[4px] text-[16px] leading-[1.5] font-medium text-[#333]">
+    <span className="inline-flex items-center gap-[4px] text-body-2 text-text-body-1">
       <Icon name={iconName} size={24} />
       {text}
     </span>
@@ -190,12 +190,10 @@ function BasicProfileCard({
 
   return (
     <section className={`${CARD_CLASS} flex flex-col gap-[25px]`}>
-      <h2 className="text-[22px] leading-[1.5] font-bold text-[#1a1a1a]">
-        {t('profile.basicProfile')}
-      </h2>
+      <h2 className="text-h2 text-text-title-2">{t('profile.basicProfile')}</h2>
       <div className="flex items-center gap-[25px]">
         <div className="flex flex-col items-center gap-[10px]">
-          <div className="flex h-[200px] w-[200px] items-center justify-center overflow-hidden rounded-full bg-[#e6e6e6]">
+          <div className="flex h-[200px] w-[200px] items-center justify-center overflow-hidden rounded-full bg-gray-100">
             {profilePublic?.profileImageUrl ? (
               <Image
                 src={profilePublic.profileImageUrl}
@@ -226,11 +224,11 @@ function BasicProfileCard({
 
         <div className="flex min-w-0 flex-1 flex-col gap-[20px]">
           <div className="flex flex-col pb-px">
-            <h3 className="text-[30px] leading-[1.5] font-bold text-[#1f1d1b]">
+            <h3 className="text-title text-text-title-2">
               {firstName} {lastName}
             </h3>
             {profilePublic?.dateOfBirth && (
-              <p className="text-[16px] leading-[1.5] font-medium text-[#666]">
+              <p className="text-body-2 text-text-sub-1">
                 {formatDob(profilePublic.dateOfBirth, locale)}
               </p>
             )}
@@ -258,9 +256,7 @@ function BasicProfileCard({
 
           {summary && (
             <div className="rounded-[10px] bg-white p-[20px]">
-              <p className="text-[18px] leading-[1.5] font-medium text-[#333]">
-                {summary}
-              </p>
+              <p className="text-body-1 text-text-body-1">{summary}</p>
             </div>
           )}
         </div>
@@ -282,7 +278,7 @@ function EducationSection({
     <section className={`${CARD_CLASS} flex flex-col gap-[25px]`}>
       <SectionTitle title={t('profile.education')} />
       {educations.length === 0 ? (
-        <p className="text-[16px] leading-[1.5] font-medium text-[#666]">
+        <p className="text-body-2 text-text-sub-1">
           {t('profile.empty.education')}
         </p>
       ) : (
@@ -298,10 +294,10 @@ function EducationSection({
 
             return (
               <li key={education.id} className="flex flex-col">
-                <p className="text-[20px] leading-[1.5] font-bold text-[#333]">
+                <p className="text-h3 text-text-body-1">
                   {education.institutionName}
                 </p>
-                <div className="flex flex-wrap items-center gap-[10px] text-[16px] leading-[1.5] font-medium text-[#666]">
+                <div className="flex flex-wrap items-center gap-[10px] text-body-2 text-text-sub-1">
                   <span>{formatMonthYear(education.startDate, locale)}</span>
                   <span>-</span>
                   <span>
@@ -328,7 +324,7 @@ function SkillsSection({ skills, t }: { skills: Skill[]; t: Translator }) {
     <section className={`${CARD_CLASS} flex flex-col gap-[40px]`}>
       <SectionTitle title={t('profile.skills')} />
       {skills.length === 0 ? (
-        <p className="text-[16px] leading-[1.5] font-medium text-[#666]">
+        <p className="text-body-2 text-text-sub-1">
           {t('profile.empty.skills')}
         </p>
       ) : (
@@ -358,7 +354,7 @@ function ExperienceSection({
     <section className={`${CARD_CLASS} flex flex-col gap-[40px]`}>
       <SectionTitle title={t('profile.experience')} />
       {careers.length === 0 ? (
-        <p className="text-[16px] leading-[1.5] font-medium text-[#666]">
+        <p className="text-body-2 text-text-sub-1">
           {t('profile.empty.career')}
         </p>
       ) : (
@@ -376,11 +372,11 @@ function ExperienceSection({
               <li key={career.id} className="flex flex-col gap-[20px]">
                 <div className="flex flex-col gap-[10px]">
                   <div className="flex flex-wrap items-center gap-[10px]">
-                    <p className="text-[20px] leading-[1.5] font-bold text-[#333]">
+                    <p className="text-h3 text-text-body-1">
                       {career.companyName}
                     </p>
                     <Divider />
-                    <div className="flex items-center gap-[4px] text-[14px] leading-[1.5] font-medium text-[#808080]">
+                    <div className="flex items-center gap-[4px] text-caption-1 text-text-sub-2">
                       <span>{formatYear(career.startDate)}</span>
                       <span>-</span>
                       <span>
@@ -390,7 +386,7 @@ function ExperienceSection({
                       </span>
                     </div>
                   </div>
-                  <div className="flex flex-wrap items-center gap-[10px] text-[16px] leading-[1.5] font-medium text-[#4c4c4c]">
+                  <div className="flex flex-wrap items-center gap-[10px] text-body-2 text-text-body-2">
                     <span>{career.positionTitle}</span>
                     <Divider />
                     <span>{secondValue}</span>
@@ -403,7 +399,7 @@ function ExperienceSection({
                   </div>
                 </div>
                 {descriptions.length > 0 && (
-                  <ul className="list-disc space-y-[4px] pl-6 text-[16px] leading-[1.5] font-medium text-[#4c4c4c]">
+                  <ul className="list-disc space-y-[4px] pl-6 text-body-2 text-text-body-2">
                     {descriptions.map((line) => (
                       <li key={line}>{line}</li>
                     ))}
@@ -429,7 +425,7 @@ function CertificationSection({
     <section className={`${CARD_CLASS} flex flex-col gap-[40px]`}>
       <SectionTitle title={t('profile.certification')} />
       {certifications.length === 0 ? (
-        <p className="text-[16px] leading-[1.5] font-medium text-[#666]">
+        <p className="text-body-2 text-text-sub-1">
           {t('profile.empty.certifications')}
         </p>
       ) : (
@@ -437,16 +433,14 @@ function CertificationSection({
           {certifications.map((certification) => (
             <li key={certification.id} className="flex flex-col gap-[10px]">
               <div className="flex flex-wrap items-center gap-[10px]">
-                <p className="text-[20px] leading-[1.5] font-bold text-[#333]">
-                  {certification.name}
-                </p>
+                <p className="text-h3 text-text-body-1">{certification.name}</p>
                 <Divider />
-                <span className="text-[14px] leading-[1.5] font-medium text-[#808080]">
+                <span className="text-caption-1 text-text-sub-2">
                   {formatYear(certification.date)}
                 </span>
               </div>
               {normalizeText(certification.institutionName) && (
-                <p className="text-[16px] leading-[1.5] font-medium text-[#4c4c4c]">
+                <p className="text-body-2 text-text-body-2">
                   {normalizeText(certification.institutionName)}
                 </p>
               )}
@@ -469,7 +463,7 @@ function LanguageSection({
     <section className={`${CARD_CLASS} flex flex-col gap-[40px]`}>
       <SectionTitle title={t('profile.languages')} />
       {languages.length === 0 ? (
-        <p className="text-[16px] leading-[1.5] font-medium text-[#666]">
+        <p className="text-body-2 text-text-sub-1">
           {t('profile.empty.languages')}
         </p>
       ) : (
@@ -477,17 +471,15 @@ function LanguageSection({
           {languages.map((language) => (
             <li key={language.id} className="flex flex-col gap-[10px]">
               <div className="flex flex-wrap items-center gap-[10px]">
-                <p className="text-[20px] leading-[1.5] font-bold text-[#333]">
-                  {language.language}
-                </p>
+                <p className="text-h3 text-text-body-1">{language.language}</p>
                 <Divider />
-                <span className="text-[16px] leading-[1.5] font-medium text-[#808080]">
+                <span className="text-body-2 text-text-sub-2">
                   {getProficiencyLabel(language.proficiency, t)}
                 </span>
               </div>
               {normalizeText(language.testName) &&
                 normalizeText(language.testScore) && (
-                  <p className="text-[16px] leading-[1.5] font-medium text-[#4c4c4c]">
+                  <p className="text-body-2 text-text-body-2">
                     {language.testName} · {language.testScore}
                   </p>
                 )}

--- a/app/(dashboard)/dashboard-sidebar.tsx
+++ b/app/(dashboard)/dashboard-sidebar.tsx
@@ -17,7 +17,7 @@ export default function DashboardSidebar() {
 
   return (
     <aside className="flex w-[220px] shrink-0 flex-col px-5 py-8">
-      <p className="mb-[40px] text-[30px] leading-[1.5] font-bold text-[#1a1a1a]">
+      <p className="mb-[40px] text-title text-text-title-2">
         {t('nav.myPage')}
       </p>
       <nav className="flex flex-1 flex-col gap-[10px]">
@@ -28,8 +28,8 @@ export default function DashboardSidebar() {
               key={href}
               href={href}
               className={[
-                'py-0 text-[26px] leading-[1.5] font-bold transition-colors',
-                isActive ? 'text-brand' : 'text-[#666] hover:text-brand',
+                'py-0 text-h1 transition-colors',
+                isActive ? 'text-brand' : 'text-text-sub-1 hover:text-brand',
               ].join(' ')}
             >
               {t(labelKey)}
@@ -41,7 +41,7 @@ export default function DashboardSidebar() {
         onClick={() =>
           signOut({ fetchOptions: { onSuccess: () => router.push('/jobs') } })
         }
-        className="mt-4 text-left text-[18px] leading-[1.5] font-medium text-[#999] transition-colors hover:text-[#333]"
+        className="mt-4 text-left text-body-1 text-text-info transition-colors hover:text-text-body-1"
       >
         {t('nav.logout')}
       </button>

--- a/app/announcements/[id]/loading.tsx
+++ b/app/announcements/[id]/loading.tsx
@@ -10,7 +10,7 @@ export default function AnnouncementDetailLoading() {
         <Skeleton className="h-5 w-48" />
       </div>
 
-      <div className="rounded-[20px] bg-[#fbfbfb] px-[20px] pt-[20px] pb-[40px]">
+      <div className="rounded-[20px] bg-bg px-[20px] pt-[20px] pb-[40px]">
         <div className="flex flex-col gap-3">
           <Skeleton className="h-4 w-full" />
           <Skeleton className="h-4 w-[95%]" />

--- a/app/announcements/[id]/not-found.tsx
+++ b/app/announcements/[id]/not-found.tsx
@@ -7,10 +7,10 @@ export default async function AnnouncementNotFound() {
 
   return (
     <div className="mx-auto flex w-full max-w-[1200px] flex-col items-center gap-3 px-6 py-10 text-center">
-      <h1 className="text-2xl font-semibold text-[#1a1a1a]">
+      <h1 className="text-h2 font-semibold text-text-title-2">
         {t('announcements.notFound.title')}
       </h1>
-      <p className="text-sm text-[#666]">
+      <p className="text-sm text-text-sub-1">
         {t('announcements.notFound.description')}
       </p>
       <Button asChild variant="brand" size="brand-sm">

--- a/app/announcements/[id]/page.tsx
+++ b/app/announcements/[id]/page.tsx
@@ -52,29 +52,27 @@ export default async function AnnouncementDetailPage({
       <Link
         href="/announcements"
         aria-label={t('announcements.backAria')}
-        className="inline-flex w-fit items-center text-black hover:text-brand"
+        className="inline-flex w-fit items-center text-text-title-1 hover:text-brand"
       >
         <Icon name="chevron-left" size={24} />
       </Link>
 
       <div className="flex flex-col gap-2">
-        <h1 className="text-[30px] leading-[1.5] font-bold text-black">
-          {announcement.title}
-        </h1>
-        <div className="inline-flex items-center gap-[5px] text-[14px] leading-[1.5] font-medium text-[#808080]">
+        <h1 className="text-title text-text-title-1">{announcement.title}</h1>
+        <div className="inline-flex items-center gap-[5px] text-caption-1 text-text-sub-2">
           {announcement.isPinned && <span>({t('announcements.pinned')})</span>}
           <span>{formatDate(announcement.createdAt)}</span>
         </div>
       </div>
 
-      <div className="rounded-[20px] bg-[#fbfbfb] px-[20px] pt-[20px] pb-[40px]">
-        <div className="text-[18px] leading-[1.5] font-medium text-[#4c4c4c] [&_h2]:mb-[40px] [&_h2]:border-b [&_h2]:border-[#d7d7d7] [&_h2]:pb-[10px] [&_h2]:text-[22px] [&_h2]:leading-[1.5] [&_h2]:font-bold [&_h2]:text-[#1a1a1a] [&_h2:not(:first-of-type)]:mt-[80px] [&_li]:mb-[4px] [&_li:last-child]:mb-0 [&_p]:m-0 [&_ul]:m-0 [&_ul]:list-disc [&_ul]:pl-[27px]">
+      <div className="rounded-[20px] bg-bg px-[20px] pt-[20px] pb-[40px]">
+        <div className="text-body-1 text-text-body-2 [&_h2]:mb-[40px] [&_h2]:border-b [&_h2]:border-gray-200 [&_h2]:pb-[10px] [&_h2]:text-h2 [&_h2]:text-text-title-2 [&_h2:not(:first-of-type)]:mt-[80px] [&_li]:mb-[4px] [&_li:last-child]:mb-0 [&_p]:m-0 [&_ul]:m-0 [&_ul]:list-disc [&_ul]:pl-[27px]">
           <ReactMarkdown>{announcement.content}</ReactMarkdown>
         </div>
       </div>
 
       <div className="flex flex-col">
-        <div className="grid grid-cols-[94px_1fr_193px] items-center gap-[30px] border-y border-black py-5 text-[14px] leading-[1.5] font-medium text-[#4c4c4c]">
+        <div className="grid grid-cols-[94px_1fr_193px] items-center gap-[30px] border-y border-black py-5 text-caption-1 text-text-body-2">
           <span className="text-center">{t('announcements.next')}</span>
           {neighbors.next ? (
             <Link
@@ -84,14 +82,16 @@ export default async function AnnouncementDetailPage({
               {neighbors.next.title}
             </Link>
           ) : (
-            <span className="text-[#999]">{t('announcements.noneNext')}</span>
+            <span className="text-text-info">
+              {t('announcements.noneNext')}
+            </span>
           )}
           <span className="text-center">
             {neighbors.next ? formatDate(neighbors.next.createdAt) : '-'}
           </span>
         </div>
 
-        <div className="grid grid-cols-[94px_1fr_193px] items-center gap-[30px] border-b border-black py-5 text-[14px] leading-[1.5] font-medium text-[#4c4c4c]">
+        <div className="grid grid-cols-[94px_1fr_193px] items-center gap-[30px] border-b border-black py-5 text-caption-1 text-text-body-2">
           <span className="text-center">{t('announcements.before')}</span>
           {neighbors.before ? (
             <Link
@@ -101,7 +101,9 @@ export default async function AnnouncementDetailPage({
               {neighbors.before.title}
             </Link>
           ) : (
-            <span className="text-[#999]">{t('announcements.noneBefore')}</span>
+            <span className="text-text-info">
+              {t('announcements.noneBefore')}
+            </span>
           )}
           <span className="text-center">
             {neighbors.before ? formatDate(neighbors.before.createdAt) : '-'}

--- a/app/announcements/error.tsx
+++ b/app/announcements/error.tsx
@@ -20,10 +20,10 @@ export default function AnnouncementsError({
 
   return (
     <div className="mx-auto flex w-full max-w-[1200px] flex-col items-center gap-3 px-6 py-10 text-center">
-      <h1 className="text-2xl font-semibold text-[#1a1a1a]">
+      <h1 className="text-h2 font-semibold text-text-title-2">
         {t('announcements.error.title')}
       </h1>
-      <p className="text-sm text-[#666]">
+      <p className="text-sm text-text-sub-1">
         {t('announcements.error.description')}
       </p>
       <div className="flex items-center gap-2">

--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -44,7 +44,7 @@ export default async function AnnouncementsPage({
   return (
     <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-6 px-6 py-10">
       <div className="flex flex-col gap-[25px]">
-        <h2 className="text-[22px] font-bold text-[#1a1a1a]">
+        <h2 className="text-h2 text-text-title-2">
           {t('announcements.title')}
         </h2>
 
@@ -60,7 +60,7 @@ export default async function AnnouncementsPage({
             return (
               <div
                 key={item.id}
-                className="grid grid-cols-[96px_1fr_192px] items-center gap-[30px] border-b border-black py-5 text-lg font-medium text-[#333]"
+                className="grid grid-cols-[96px_1fr_192px] items-center gap-[30px] border-b border-black py-5 text-lg font-medium text-text-body-1"
               >
                 <span className="text-center">
                   {item.isPinned ? '📍' : rowNumber}

--- a/app/candidate/[slug]/page.tsx
+++ b/app/candidate/[slug]/page.tsx
@@ -46,9 +46,7 @@ export default async function CandidateLandingPage({
   return (
     <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-[40px] px-6 py-8">
       <section className="flex flex-col gap-[10px]">
-        <h2 className="text-[26px] leading-[1.5] font-bold text-[#1a1a1a]">
-          {t('profile.myProfile')}
-        </h2>
+        <h2 className="text-h1 text-text-title-2">{t('profile.myProfile')}</h2>
         <ProfileCard
           firstName={profilePublic?.firstName ?? ''}
           lastName={profilePublic?.lastName ?? ''}
@@ -64,25 +62,19 @@ export default async function CandidateLandingPage({
 
       {isOwner && (
         <section className="flex flex-col gap-[20px]">
-          <h2 className="text-[26px] leading-[1.5] font-bold text-[#1a1a1a]">
-            {t('profile.myJobs')}
-          </h2>
+          <h2 className="text-h1 text-text-title-2">{t('profile.myJobs')}</h2>
           <div className="grid grid-cols-1 gap-[10px] md:grid-cols-2">
-            <div className="rounded-[20px] bg-[#fbfbfb] px-10 py-[50px] text-center">
-              <p className="text-[22px] leading-[1.5] font-bold text-[#1a1a1a]">
+            <div className="rounded-[20px] bg-bg px-10 py-[50px] text-center">
+              <p className="text-h2 text-text-title-2">
                 {t('profile.applied')}
               </p>
-              <p className="text-[22px] leading-[1.5] font-bold text-[#1a1a1a]">
-                {appliedCount}
-              </p>
+              <p className="text-h2 text-text-title-2">{appliedCount}</p>
             </div>
-            <div className="rounded-[20px] bg-[#fbfbfb] px-10 py-[50px] text-center">
-              <p className="text-[22px] leading-[1.5] font-bold text-[#333]">
+            <div className="rounded-[20px] bg-bg px-10 py-[50px] text-center">
+              <p className="text-h2 text-text-body-1">
                 {t('profile.inProgress')}
               </p>
-              <p className="text-[22px] leading-[1.5] font-bold text-[#333]">
-                {inProgressCount}
-              </p>
+              <p className="text-h2 text-text-body-1">{inProgressCount}</p>
             </div>
           </div>
         </section>

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -19,10 +19,10 @@ export default function GlobalError({
 
   return (
     <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-3xl flex-col items-center justify-center gap-4 px-6 text-center">
-      <h1 className="text-2xl font-semibold text-[#1a1a1a]">
+      <h1 className="text-h2 font-semibold text-text-title-2">
         {t('global.error.title')}
       </h1>
-      <p className="text-sm text-[#666]">{t('global.error.description')}</p>
+      <p className="text-sm text-text-sub-1">{t('global.error.description')}</p>
       <Button type="button" variant="brand" size="brand-md" onClick={reset}>
         {t('global.error.retry')}
       </Button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -125,6 +125,10 @@
   --text-caption-2: 0.75rem;
   --text-caption-2--line-height: 1.5;
   --text-caption-2--font-weight: 500;
+
+  --text-display: 4.5rem;
+  --text-display--line-height: 1;
+  --text-display--font-weight: 700;
 }
 
 @custom-variant dark (&:is(.dark *));

--- a/app/jobs/[id]/_share-job-button.tsx
+++ b/app/jobs/[id]/_share-job-button.tsx
@@ -36,7 +36,7 @@ export function ShareJobButton({ title }: Props) {
     <button
       type="button"
       aria-label={t('jobs.share')}
-      className="inline-flex h-[60px] w-[60px] items-center justify-center rounded-full border border-[#f2f2f2] bg-white"
+      className="inline-flex h-[60px] w-[60px] items-center justify-center rounded-full border border-gray-50 bg-white"
       onClick={() => {
         void handleShare();
       }}

--- a/app/jobs/[id]/loading.tsx
+++ b/app/jobs/[id]/loading.tsx
@@ -20,7 +20,7 @@ export default function JobDetailLoading() {
       </div>
 
       <div className="hidden w-[300px] shrink-0 lg:block">
-        <div className="rounded-[20px] border border-[#b3b3b3] bg-white px-[20px] py-[40px]">
+        <div className="rounded-[20px] border border-gray-300 bg-white px-[20px] py-[40px]">
           <div className="flex flex-col gap-4">
             <Skeleton className="h-4 w-48" />
             <Skeleton className="h-4 w-40" />

--- a/app/jobs/[id]/page.tsx
+++ b/app/jobs/[id]/page.tsx
@@ -72,8 +72,8 @@ export default async function JobDetailPage({
         />
 
         {jd.descriptionMarkdown && (
-          <div className="w-full rounded-[20px] bg-[#fbfbfb] px-[40px] pt-[20px] pb-[40px]">
-            <div className="text-[18px] leading-[1.5] font-medium text-[#4c4c4c] [&_h2]:mb-[40px] [&_h2]:border-b [&_h2]:border-[#d7d7d7] [&_h2]:pb-[10px] [&_h2]:text-[22px] [&_h2]:leading-[1.5] [&_h2]:font-bold [&_h2]:text-[#1a1a1a] [&_h2:not(:first-of-type)]:mt-[80px] [&_li]:mb-[4px] [&_li:last-child]:mb-0 [&_p]:m-0 [&_ul]:m-0 [&_ul]:list-disc [&_ul]:pl-[27px]">
+          <div className="w-full rounded-[20px] bg-bg px-[40px] pt-[20px] pb-[40px]">
+            <div className="text-body-1 text-text-body-2 [&_h2]:mb-[40px] [&_h2]:border-b [&_h2]:border-gray-200 [&_h2]:pb-[10px] [&_h2]:text-h2 [&_h2]:text-text-title-2 [&_h2:not(:first-of-type)]:mt-[80px] [&_li]:mb-[4px] [&_li:last-child]:mb-0 [&_p]:m-0 [&_ul]:m-0 [&_ul]:list-disc [&_ul]:pl-[27px]">
               <ReactMarkdown>{jd.descriptionMarkdown}</ReactMarkdown>
             </div>
           </div>

--- a/app/jobs/_jobs-list-apply-cta.tsx
+++ b/app/jobs/_jobs-list-apply-cta.tsx
@@ -101,10 +101,10 @@ export function JobsListApplyCta({
       type="button"
       aria-disabled={isDisabled}
       className={cn(
-        'inline-flex h-[35px] min-w-[123px] items-center justify-center rounded-[60px] px-[20px] py-[8px] text-[16px] leading-none font-medium text-white transition-colors',
+        'inline-flex h-[35px] min-w-[123px] items-center justify-center rounded-[60px] px-[20px] py-[8px] text-body-2 leading-none text-white transition-colors',
         isDisabled
-          ? 'cursor-not-allowed bg-[#ccc]'
-          : 'bg-[#ff6000] hover:bg-[#e55600]'
+          ? 'cursor-not-allowed bg-gray-200'
+          : 'bg-brand hover:bg-orange-600'
       )}
       onClick={handleClick}
     >

--- a/app/jobs/loading.tsx
+++ b/app/jobs/loading.tsx
@@ -17,7 +17,7 @@ export default function JobsLoading() {
         {Array.from({ length: 4 }).map((_, index) => (
           <div
             key={`jobs-loading-item-${index}`}
-            className="rounded-[20px] border border-[#ffefe5] bg-white px-[40px] py-[20px]"
+            className="rounded-[20px] border border-brand-sub bg-white px-[40px] py-[20px]"
           >
             <div className="flex items-center gap-[20px]">
               <div className="flex w-[160px] shrink-0 items-center gap-[10px]">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -7,10 +7,12 @@ export default async function GlobalNotFound() {
 
   return (
     <div className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-3xl flex-col items-center justify-center gap-4 px-6 text-center">
-      <h1 className="text-2xl font-semibold text-[#1a1a1a]">
+      <h1 className="text-h2 font-semibold text-text-title-2">
         {t('global.notFound.title')}
       </h1>
-      <p className="text-sm text-[#666]">{t('global.notFound.description')}</p>
+      <p className="text-sm text-text-sub-1">
+        {t('global.notFound.description')}
+      </p>
       <Button asChild variant="brand" size="brand-md">
         <Link href="/jobs">{t('global.notFound.goJobs')}</Link>
       </Button>

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
         brand:
           'rounded-[60px] bg-brand text-white font-medium hover:bg-orange-600',
         'brand-outline':
-          'rounded-[60px] border border-brand bg-white text-brand font-medium hover:bg-[#fff5ef]',
+          'rounded-[60px] border border-brand bg-white text-brand font-medium hover:bg-brand-sub',
         'brand-disabled':
           'rounded-[60px] bg-gray-200 text-white font-medium cursor-not-allowed hover:bg-gray-200',
       },
@@ -31,12 +31,10 @@ const buttonVariants = cva(
         xs: "h-6 gap-1 rounded-md px-2 text-xs has-[>svg]:px-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
-        'brand-sm':
-          'h-[34px] gap-[5px] px-[10px] py-[5px] text-[length:var(--typography-body-3-font-size)]',
-        'brand-md':
-          'h-[45px] gap-[5px] px-[20px] py-[5px] text-[length:var(--typography-body-3-font-size)]',
+        'brand-sm': 'h-[34px] gap-[5px] px-[10px] py-[5px] text-body-3',
+        'brand-md': 'h-[45px] gap-[5px] px-[20px] py-[5px] text-body-3',
         'brand-lg':
-          'h-[54px] gap-[5px] px-[40px] py-[15px] text-[length:var(--typography-body-2-font-size)] font-bold',
+          'h-[54px] gap-[5px] px-[40px] py-[15px] text-body-2 font-bold',
         icon: 'size-9',
         'icon-xs': "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
         'icon-sm': 'size-8',

--- a/frontend/components/ui/toggle-switch.tsx
+++ b/frontend/components/ui/toggle-switch.tsx
@@ -35,7 +35,7 @@ export function ToggleSwitch({
       role="switch"
       aria-checked={checked}
       onClick={() => onChange(!checked)}
-      className={`relative rounded-[999px] transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-[#ff6000]/40 ${config.track} ${
+      className={`relative rounded-[999px] transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-brand/40 ${config.track} ${
         checked ? 'bg-success' : 'bg-gray-100'
       }`}
     >

--- a/frontend/features/auth/ui/login-modal.tsx
+++ b/frontend/features/auth/ui/login-modal.tsx
@@ -112,7 +112,7 @@ export function LoginModal() {
       >
         <div className="flex flex-col items-center gap-10 px-5 pt-5 pb-20">
           <div className="flex w-full items-center justify-between">
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-text-sub-1">
               {t('auth.login.noAccount')}{' '}
               <button
                 type="button"
@@ -136,14 +136,14 @@ export function LoginModal() {
               type="button"
               onClick={closeAll}
               aria-label={t('auth.login.closeAria')}
-              className="rounded-sm p-1 text-gray-950 hover:bg-[#f5f5f5]"
+              className="rounded-sm p-1 text-text-title-2 hover:bg-gray-50"
             >
               <Icon name="close" size={16} />
             </button>
           </div>
 
           <div className="flex max-w-[240px] grow-0 flex-col items-center gap-10">
-            <DialogTitle className="text-h1 text-gray-950">
+            <DialogTitle className="text-h1 text-text-title-2">
               {t('auth.login.title')}
             </DialogTitle>
             <DialogDescription className="sr-only">
@@ -191,7 +191,7 @@ export function LoginModal() {
 
             <div className="flex w-full items-center gap-2.5 overflow-hidden">
               <div className="h-px flex-1 bg-gray-300" />
-              <span className="text-sm font-medium text-gray-400">
+              <span className="text-sm font-medium text-text-info">
                 {t('common.or')}
               </span>
               <div className="h-px flex-1 bg-gray-300" />
@@ -282,7 +282,7 @@ export function LoginModal() {
                       )}
                       <button
                         type="button"
-                        className="text-right text-sm font-medium text-gray-600 hover:underline"
+                        className="text-right text-sm font-medium text-text-sub-1 hover:underline"
                       >
                         {t('auth.login.forgotPassword')}
                       </button>

--- a/frontend/features/auth/ui/signup-modal.tsx
+++ b/frontend/features/auth/ui/signup-modal.tsx
@@ -160,7 +160,7 @@ export function SignupModal() {
         >
           {step !== 'success' && (
             <div className="flex w-full items-center justify-between">
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-text-sub-1">
                 {t('auth.signup.haveAccount')}{' '}
                 <button
                   type="button"
@@ -184,7 +184,7 @@ export function SignupModal() {
                 type="button"
                 onClick={closeAll}
                 aria-label={t('auth.signup.closeAria')}
-                className="rounded-sm p-1 text-gray-950 hover:bg-[#f5f5f5]"
+                className="rounded-sm p-1 text-text-title-2 hover:bg-gray-50"
               >
                 <Icon name="close" size={16} />
               </button>
@@ -197,7 +197,7 @@ export function SignupModal() {
             </DialogDescription>
             {step === 'method' && (
               <>
-                <DialogTitle className="text-h1 text-gray-950">
+                <DialogTitle className="text-h1 text-text-title-2">
                   {t('auth.signup.title')}
                 </DialogTitle>
 
@@ -243,7 +243,7 @@ export function SignupModal() {
 
                 <div className="flex w-full items-center gap-2.5 overflow-hidden">
                   <div className="h-px flex-1 bg-gray-300" />
-                  <span className="text-sm font-medium text-gray-400">
+                  <span className="text-sm font-medium text-text-info">
                     {t('common.or')}
                   </span>
                   <div className="h-px flex-1 bg-gray-300" />
@@ -269,7 +269,7 @@ export function SignupModal() {
 
             {step === 'form' && (
               <>
-                <DialogTitle className="text-h1 text-gray-950">
+                <DialogTitle className="text-h1 text-text-title-2">
                   {t('auth.signup.title')}
                 </DialogTitle>
 
@@ -393,7 +393,7 @@ export function SignupModal() {
                   </div>
 
                   <div className="flex w-full flex-col gap-[10px]">
-                    <label className="flex h-[24px] w-full cursor-pointer items-center gap-[5px] text-sm leading-[1.5] font-medium text-gray-600">
+                    <label className="flex h-[24px] w-full cursor-pointer items-center gap-[5px] text-sm leading-[1.5] font-medium text-text-sub-1">
                       <input
                         type="checkbox"
                         className="sr-only"
@@ -463,18 +463,15 @@ export function SignupModal() {
               <div className="flex w-full flex-col items-center gap-10">
                 <div className="flex flex-col items-center gap-5">
                   <div className="flex size-[150px] items-center justify-center rounded-full bg-brand">
-                    <span
-                      aria-hidden
-                      className="text-[72px] leading-none font-bold text-white"
-                    >
+                    <span aria-hidden className="text-display text-white">
                       ✓
                     </span>
                   </div>
-                  <DialogTitle className="text-h2 text-black">
+                  <DialogTitle className="text-h2 text-text-title-1">
                     {t('auth.signup.successTitle')}
                   </DialogTitle>
                 </div>
-                <p className="text-center text-h4 text-gray-600">
+                <p className="text-center text-h4 text-text-sub-1">
                   {t('auth.signup.successDescription')}
                 </p>
                 <Button

--- a/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
+++ b/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
@@ -223,7 +223,7 @@ function SectionHeader({
   return (
     <div className="flex flex-col gap-[10px]">
       <div className="flex items-start justify-between">
-        <h2 className="text-h2 text-gray-950">{title}</h2>
+        <h2 className="text-h2 text-text-title-2">{title}</h2>
         {onAdd && (
           <button
             type="button"
@@ -231,7 +231,7 @@ function SectionHeader({
             className="flex size-[42px] items-center justify-center"
             aria-label={addAriaLabel ?? title}
           >
-            <span className="text-title text-gray-950">+</span>
+            <span className="text-title text-text-title-2">+</span>
           </button>
         )}
       </div>
@@ -700,7 +700,9 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
     <>
       <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-[40px] px-6 py-10 pb-[140px]">
         <section className={BASIC_SECTION_CLASS}>
-          <h2 className="text-h2 text-gray-950">{t('profile.basicProfile')}</h2>
+          <h2 className="text-h2 text-text-title-2">
+            {t('profile.basicProfile')}
+          </h2>
 
           <div className="mt-[25px] flex flex-col gap-6 lg:flex-row lg:items-start">
             <div className="flex flex-col items-center gap-4">
@@ -712,7 +714,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                 />
               </div>
               <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-gray-950">
+                <span className="text-sm font-medium text-text-title-2">
                   {t('profile.hiringStatus')}
                 </span>
                 <ToggleSwitch
@@ -747,7 +749,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
               </div>
 
               <div className="flex items-center gap-3">
-                <span className="text-sm font-medium text-gray-950">
+                <span className="text-sm font-medium text-text-title-2">
                   {t('form.dateOfBirth')}
                 </span>
                 <DatePicker
@@ -1523,16 +1525,16 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
           <div className="mt-[25px] flex flex-col gap-[25px]">
             <button
               type="button"
-              className="flex h-[52px] w-full items-center justify-center gap-1 rounded-[10px] bg-[#f8f8f8] px-[20px] text-caption-1 text-gray-600"
+              className="flex h-[52px] w-full items-center justify-center gap-1 rounded-[10px] bg-bg px-[20px] text-caption-1 text-text-sub-1"
             >
               <Icon name="plus" size={16} />
               {t('profile.upload.file')}
             </button>
             <div className="flex items-center justify-between">
-              <p className="text-body-1 text-gray-800">
+              <p className="text-body-1 text-text-body-1">
                 {t('profile.upload.uploadedFile')}
               </p>
-              <p className="text-body-2 text-gray-500">-</p>
+              <p className="text-body-2 text-text-sub-2">-</p>
             </div>
           </div>
         </section>

--- a/frontend/widgets/nav/ui/main-nav.tsx
+++ b/frontend/widgets/nav/ui/main-nav.tsx
@@ -63,7 +63,7 @@ export default function MainNav() {
       <div className="flex items-center gap-[40px]">
         <Link
           href="/jobs"
-          className="flex h-[50px] items-center rounded-[80px] bg-white px-[20px] font-[Oswald] text-[32px] leading-none font-semibold tracking-tight shadow-[0_0_15px_rgba(255,149,84,0.2)]"
+          className="flex h-[50px] items-center rounded-[80px] bg-white px-[20px] font-[Oswald] text-title leading-none font-semibold tracking-tight shadow-[0_0_15px_rgba(255,149,84,0.2)]"
         >
           VRIDGE<span className="text-brand">.</span>
         </Link>
@@ -77,7 +77,9 @@ export default function MainNav() {
                 href={href}
                 className={[
                   'text-h2 transition-colors',
-                  isActive ? 'text-brand' : 'text-gray-950 hover:text-brand',
+                  isActive
+                    ? 'text-brand'
+                    : 'text-text-title-2 hover:text-brand',
                 ].join(' ')}
               >
                 {label}
@@ -105,7 +107,7 @@ export default function MainNav() {
             <button
               type="button"
               onClick={handleOpenLogin}
-              className="text-body-1 text-gray-950 hover:text-brand"
+              className="text-body-1 text-text-title-2 hover:text-brand"
             >
               {t('nav.login')}
             </button>
@@ -113,7 +115,7 @@ export default function MainNav() {
             <button
               type="button"
               onClick={handleOpenSignup}
-              className="text-body-1 text-gray-950 hover:text-brand"
+              className="text-body-1 text-text-title-2 hover:text-brand"
             >
               {t('nav.signup')}
             </button>


### PR DESCRIPTION
## 🔥 PR 제목

> refactor(ui): 하드코딩 Tailwind 텍스트/색상 토큰 치환

## ✨ 작업 내용

- `app/globals.css`에 `--text-display` 타이포그래피 토큰을 추가했습니다.
- `app/` 및 주요 `frontend/` UI 파일에서 하드코딩된 텍스트 크기(`text-[Npx]`)와 헥스 색상(`text-[#...]`, `bg-[#...]`, `border-[#...]`)을 디자인 토큰 기반 클래스(`text-h*`, `text-body-*`, `text-caption-*`, `text-text-*`, `bg-bg` 등)로 치환했습니다.
- 버튼 브랜드 사이즈의 하드코딩 타이포그래피 클래스(`text-[length:var(--typography-...)]`)를 토큰 클래스(`text-body-2/3`)로 교체했습니다.
- 클래스명 변경에 맞춰 관련 단위 테스트 기대값을 업데이트했습니다.
- 관련 이슈: #76

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다. (N/A: 코드 주석/문서 변경 불필요)
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- `pnpm lint`
- `pnpm test --runInBand`

## 📸 스크린샷 / 시연 (선택)

- N/A

## 🙏 리뷰어에게 한마디

- 이번 PR은 하드코딩된 텍스트/색상 클래스 제거와 토큰 정렬에 집중했습니다.
- 잔여 `text-sm`, `text-xs`, `text-gray-*` 계열의 전면 semantic 토큰화는 범위가 커서 별도 후속 작업으로 분리하는 편이 안전합니다.
