### PR TITLE
fix(auth): 인증 모달 내부 폭 축소 정합성 수정

### DIFF
--- a/frontend/features/auth/ui/login-modal.tsx
+++ b/frontend/features/auth/ui/login-modal.tsx
@@ -142,7 +142,7 @@ export function LoginModal() {
             </button>
           </div>
 
-          <div className="flex max-w-[240px] grow-0 flex-col items-center gap-10">
+          <div className="flex w-full max-w-[440px] flex-col items-center gap-10">
             <DialogTitle className="text-h1 text-text-title-2">
               {t('auth.login.title')}
             </DialogTitle>

--- a/frontend/features/auth/ui/signup-modal.tsx
+++ b/frontend/features/auth/ui/signup-modal.tsx
@@ -191,7 +191,7 @@ export function SignupModal() {
             </div>
           )}
 
-          <div className="flex max-w-[240px] grow-0 flex-col items-center gap-10">
+          <div className="flex w-full max-w-[440px] flex-col items-center gap-10">
             <DialogDescription className="sr-only">
               {t('auth.signup.description')}
             </DialogDescription>


### PR DESCRIPTION
## 🔥 PR 제목

fix(auth): 인증 모달 내부 폭 축소 정합성 수정

## ✨ 작업 내용

- 관련 이슈: #78
- `frontend/features/auth/ui/signup-modal.tsx` 내부 콘텐츠 래퍼 클래스를 `w-full max-w-[440px]` 기준으로 정렬
- `frontend/features/auth/ui/login-modal.tsx`에도 동일한 폭 정렬 규칙 적용
- `grow-0` 기반 축소 가능 상태를 제거해 모달 내부 컨텐츠 폭 일관성 확보

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다. (N/A: 코드 동작 변경만 있어 문서 변경 불필요)
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- 실행 명령어:
  - `pnpm test -- __tests__/features/auth/login-modal.test.tsx __tests__/features/auth/signup-modal.test.tsx`
- 결과:
  - Test Suites: 2 passed, 2 total
  - Tests: 20 passed, 20 total

## 📸 스크린샷 / 시연 (선택)

- N/A (UI 동작은 클래스 변경 중심이며, 시연 자료는 별도 첨부하지 않음)

## 🙏 리뷰어에게 한마디

- 이번 PR은 인증 모달 내부 레이아웃 폭 정합성만 최소 범위로 수정했습니다.
- 작업 트리의 다른 로컬 변경사항(프로필 페이지 관련)은 의도적으로 포함하지 않았습니다.
