### PR TITLE
fix(profile/edit): 프로필 수정 페이지 UI 정합성 및 편집 상태 표시 개선

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Rule #1: If you want exception to ANY rule, YOU MUST STOP and get explicit permi
 
 ### Preflight 1: Feature Branch Creation (BEFORE implementing plan)
 
-- ALWAYS identify the remote default base branch (for example `origin/HEAD` -> `main` or `master`).
+- ALWAYS use `dev` as the base branch for preflight sync (do not infer from `origin/HEAD`).
 - ALWAYS update the base branch using fetch + fast-forward-only. If sync fails, STOP and ask Ori.
 - ALWAYS create a feature branch using `type/scope-topic` naming.
 - ALWAYS use `git worktree` by default. A normal branch checkout is allowed only when work is single-threaded or worktree setup is blocked.

--- a/__tests__/components/ui/form-input.test.tsx
+++ b/__tests__/components/ui/form-input.test.tsx
@@ -22,10 +22,10 @@ describe('FormInput', () => {
     expect(textarea).toHaveClass('h-[130px]');
   });
 
-  it('기본 상태: bg-bg 배경', () => {
+  it('기본 상태: white 배경', () => {
     renderWithI18n(<FormInput placeholder="Test" />);
     const input = screen.getByPlaceholderText('Test');
-    expect(input).toHaveClass('bg-bg');
+    expect(input).toHaveClass('bg-white');
   });
 
   it('filled 상태: bg-white + border', () => {

--- a/app/globals.css
+++ b/app/globals.css
@@ -177,7 +177,7 @@
 
 :root {
   --radius: 0.625rem;
-  --background: var(--color-bg);
+  --background: var(--color-white);
   --foreground: var(--color-black);
   --card: var(--color-white);
   --card-foreground: var(--color-black);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { Inter, Geist_Mono } from 'next/font/google';
+import { Inter } from 'next/font/google';
 import { Suspense } from 'react';
 import './globals.css';
 import Providers from '@/frontend/components/providers';
@@ -14,11 +14,6 @@ import { getServerI18n } from '@/shared/i18n/server';
 
 const inter = Inter({
   variable: '--font-inter',
-  subsets: ['latin'],
-});
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
   subsets: ['latin'],
 });
 
@@ -40,7 +35,7 @@ export default async function RootLayout({
 
   return (
     <html lang={locale}>
-      <body className={`${inter.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${inter.variable} antialiased`}>
         <Providers locale={locale} messages={messages}>
           <MainNav />
           {children}

--- a/frontend/components/ui/form-input.tsx
+++ b/frontend/components/ui/form-input.tsx
@@ -6,12 +6,14 @@ import { useI18n } from '@/shared/i18n/client';
 
 type FormInputSize = 'sm' | 'md' | 'lg';
 type FormInputVariant = 'default' | 'file';
+type FormThemeVariant = 'white' | 'bg';
 
 type FormInputProps = {
   size?: FormInputSize;
   filled?: boolean;
   required?: boolean;
   variant?: FormInputVariant;
+  theme?: FormThemeVariant;
 } & Omit<ComponentPropsWithoutRef<'input'>, 'size'> &
   Omit<ComponentPropsWithoutRef<'textarea'>, 'size'>;
 
@@ -33,6 +35,7 @@ export const FormInput = forwardRef<
     filled = false,
     required = false,
     variant = 'default',
+    theme = 'white',
     className,
     ...props
   },
@@ -56,9 +59,10 @@ export const FormInput = forwardRef<
     );
   }
 
-  const stateClass = filled ? 'bg-white border border-gray-300' : 'bg-bg';
+  const stateClass = filled ? 'border border-gray-300' : '';
+  const themeClass = `bg-${theme}`;
 
-  const combinedClass = `${baseClass} ${SIZE_CLASS[size]} ${stateClass} ${className ?? ''}`;
+  const combinedClass = `${baseClass} ${SIZE_CLASS[size]} ${stateClass} ${themeClass} ${className ?? ''}`;
 
   return (
     <span className="relative inline-flex w-full items-center">

--- a/frontend/components/ui/social-ls.tsx
+++ b/frontend/components/ui/social-ls.tsx
@@ -54,7 +54,7 @@ export function SocialLs({
       ) : (
         <Icon name={meta.iconName} size={meta.iconSize} alt={provider} />
       )}
-      <span className="text-center text-body-2 text-gray-800">{label}</span>
+      <span className="text-center text-[15px] text-gray-800">{label}</span>
     </button>
   );
 }

--- a/frontend/entities/job/ui/posting-list-item.tsx
+++ b/frontend/entities/job/ui/posting-list-item.tsx
@@ -75,7 +75,7 @@ export function PostingListItem({
             <div className="flex min-w-0 flex-1 flex-col gap-[20px] rounded-[20px] p-[20px]">
               <h3 className="text-h3 text-black">{title}</h3>
 
-              <div className="flex flex-wrap items-center gap-[20px] text-body-2 text-gray-800">
+              <div className="flex flex-wrap items-center gap-[20px] text-body-3 text-gray-800">
                 <span className="inline-flex items-center gap-[5px]">
                   <Icon name="jobs" size={24} />
                   {jobDisplayName}

--- a/frontend/features/profile-edit/model/use-unsaved-changes-guard.ts
+++ b/frontend/features/profile-edit/model/use-unsaved-changes-guard.ts
@@ -1,11 +1,10 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-
-const LEAVE_MESSAGE =
-  '저장되지 않은 변경사항이 있습니다. 페이지를 벗어나시겠어요?';
+import { useI18n } from '@/shared/i18n/client';
 
 export function useUnsavedChangesGuard(isDirty: boolean) {
+  const { t } = useI18n();
   const dirtyRef = useRef(isDirty);
 
   useEffect(() => {
@@ -18,13 +17,12 @@ export function useUnsavedChangesGuard(isDirty: boolean) {
     }
 
     function confirmLeave() {
-      return window.confirm(LEAVE_MESSAGE);
+      return window.confirm(t('common.actions.warnDirty'));
     }
 
     function handleBeforeUnload(event: BeforeUnloadEvent) {
       if (!shouldBlock()) return;
       event.preventDefault();
-      event.returnValue = '';
     }
 
     function handleClickCapture(event: MouseEvent) {
@@ -64,5 +62,5 @@ export function useUnsavedChangesGuard(isDirty: boolean) {
       document.removeEventListener('click', handleClickCapture, true);
       window.removeEventListener('popstate', handlePopState);
     };
-  }, []);
+  }, [t]);
 }

--- a/frontend/features/profile-edit/ui/certification-form.tsx
+++ b/frontend/features/profile-edit/ui/certification-form.tsx
@@ -96,6 +96,7 @@ export function CertificationForm({
               onChange={(e) => field.handleChange(e.target.value)}
               onBlur={field.handleBlur}
               filled={field.state.value.length > 0}
+              theme="bg"
             />
             {field.state.meta.isTouched && (
               <FieldError errors={field.state.meta.errors} />
@@ -138,6 +139,7 @@ export function CertificationForm({
               onChange={(e) => field.handleChange(e.target.value || undefined)}
               onBlur={field.handleBlur}
               filled={Boolean(field.state.value)}
+              theme="bg"
             />
           </div>
         )}
@@ -156,6 +158,7 @@ export function CertificationForm({
               onChange={(e) => field.handleChange(e.target.value || undefined)}
               onBlur={field.handleBlur}
               filled={Boolean(field.state.value)}
+              theme="bg"
             />
           </div>
         )}

--- a/frontend/features/profile-edit/ui/language-form.tsx
+++ b/frontend/features/profile-edit/ui/language-form.tsx
@@ -152,6 +152,7 @@ export function LanguageForm({
               onChange={(e) => field.handleChange(e.target.value || undefined)}
               onBlur={field.handleBlur}
               filled={Boolean(field.state.value)}
+              theme="bg"
             />
           </div>
         )}
@@ -167,6 +168,7 @@ export function LanguageForm({
               onChange={(e) => field.handleChange(e.target.value || undefined)}
               onBlur={field.handleBlur}
               filled={Boolean(field.state.value)}
+              theme="bg"
             />
           </div>
         )}

--- a/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
+++ b/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
@@ -193,7 +193,7 @@ const EMPTY_URL: Omit<DraftUrl, 'id'> = {
 
 const BASE_SECTION_CLASS = 'w-full rounded-[20px] px-[20px]';
 const BASIC_SECTION_CLASS =
-  'w-full rounded-[20px] bg-white px-[40px] py-[20px]';
+  'w-full rounded-[20px] bg-white px-[40px] py-[20px] border-2 border-transparent focus-within:border-brand-sub';
 const TOP_PADDED_SECTION_CLASS = `${BASE_SECTION_CLASS} pt-[20px]`;
 
 const CORE_EDUCATION_ORDER = [
@@ -874,7 +874,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
             {draft.educations.map((education) => (
               <div
                 key={education.id}
-                className="relative rounded-[20px] border-2 border-brand-sub p-[20px]"
+                className="relative rounded-[20px] border-2 border-transparent p-[20px] focus-within:border-brand-sub"
               >
                 <Button
                   type="button"
@@ -1116,7 +1116,10 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
           />
           <div className="mt-[25px] flex flex-col gap-[25px]">
             {draft.careers.map((career) => (
-              <div key={career.id} className="relative rounded-[20px] p-[20px]">
+              <div
+                key={career.id}
+                className="relative rounded-[20px] border-2 border-transparent p-[20px] focus-within:border-brand-sub"
+              >
                 <Button
                   type="button"
                   variant="ghost"
@@ -1331,7 +1334,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
             {draft.certifications.map((certification) => (
               <div
                 key={certification.id}
-                className="relative rounded-[20px] p-[20px]"
+                className="relative rounded-[20px] border-2 border-transparent p-[20px] focus-within:border-brand-sub"
               >
                 <Button
                   type="button"
@@ -1453,7 +1456,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
             {draft.languages.map((language) => (
               <div
                 key={language.id}
-                className="relative rounded-[20px] p-[20px]"
+                className="relative rounded-[20px] border-2 border-transparent p-[20px] focus-within:border-brand-sub"
               >
                 <Button
                   type="button"
@@ -1592,7 +1595,10 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
           />
           <div className="mt-[25px] flex flex-col gap-[25px]">
             {draft.urls.map((url) => (
-              <div key={url.id} className="relative rounded-[20px] p-[20px]">
+              <div
+                key={url.id}
+                className="relative rounded-[20px] border-2 border-transparent p-[20px] focus-within:border-brand-sub"
+              >
                 <Button
                   type="button"
                   variant="ghost"

--- a/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
+++ b/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
@@ -192,7 +192,7 @@ const EMPTY_URL: Omit<DraftUrl, 'id'> = {
 };
 
 const BASE_SECTION_CLASS = 'w-full rounded-[20px] px-[40px] py-[20px]';
-const BASIC_SECTION_CLASS = `${BASE_SECTION_CLASS} border-2 border-brand-sub bg-white`;
+const BASIC_SECTION_CLASS = `${BASE_SECTION_CLASS} bg-white`;
 
 const CORE_EDUCATION_ORDER = [
   'vet_elementary',
@@ -736,6 +736,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                     updateDraftPublic('firstName', event.target.value)
                   }
                   filled={draft.public.firstName.length > 0}
+                  theme="bg"
                 />
                 <FormInput
                   required
@@ -745,6 +746,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                     updateDraftPublic('lastName', event.target.value)
                   }
                   filled={draft.public.lastName.length > 0}
+                  theme="bg"
                 />
               </div>
 
@@ -779,7 +781,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                     onChange={(code) => updateDraftContact('dialCode', code)}
                   />
                   <FormInput
-                    className="h-11 bg-transparent"
+                    className="h-11"
                     required
                     placeholder={t('form.phoneNumber')}
                     value={draft.contact.phoneNumber}
@@ -787,18 +789,20 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       updateDraftContact('phoneNumber', event.target.value)
                     }
                     filled={draft.contact.phoneNumber.length > 0}
+                    theme="bg"
                   />
                 </div>
 
                 <div className="flex items-center gap-2 rounded-[10px] bg-bg px-3 py-2">
                   <Icon name="mail" size={20} />
                   <FormInput
-                    className="h-11 bg-transparent"
+                    className="h-11"
                     placeholder={t('form.email')}
                     value={draft.contact.email}
                     filled
                     disabled
                     readOnly
+                    theme="bg"
                   />
                 </div>
               </div>
@@ -807,13 +811,14 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                 <Icon name="location" size={20} />
                 <FormInput
                   required
-                  className="h-11 bg-transparent"
+                  className="h-11"
                   placeholder={t('form.location')}
                   value={draft.public.location}
                   onChange={(event) =>
                     updateDraftPublic('location', event.target.value)
                   }
                   filled={draft.public.location.length > 0}
+                  theme="bg"
                 />
               </div>
 
@@ -826,6 +831,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                   updateDraftPublic('headline', event.target.value)
                 }
                 filled={draft.public.headline.length > 0}
+                theme="bg"
               />
 
               <FormInput
@@ -836,6 +842,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                   updateDraftPublic('aboutMe', event.target.value)
                 }
                 filled={draft.public.aboutMe.length > 0}
+                theme="bg"
               />
             </div>
           </div>
@@ -875,7 +882,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                   >
-                    {t('common.actions.delete')}
+                    <Icon name="close" size={24} />
                   </Button>
                 </div>
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -894,6 +901,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={education.institutionName.length > 0}
+                    theme="bg"
                   />
                   <FormDropdown
                     value={education.educationType}
@@ -930,6 +938,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={Boolean(education.field)}
+                    theme="bg"
                   />
                 </div>
 
@@ -1113,7 +1122,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                   >
-                    {t('common.actions.delete')}
+                    <Icon name="close" size={24} />
                   </Button>
                 </div>
 
@@ -1132,6 +1141,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={career.companyName.length > 0}
+                    theme="bg"
                   />
                   <div className="flex items-center gap-2">
                     <DatePicker
@@ -1180,6 +1190,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={career.positionTitle.length > 0}
+                    theme="bg"
                   />
 
                   <Select
@@ -1283,6 +1294,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={Boolean(career.description)}
+                    theme="bg"
                   />
                 </div>
               </div>
@@ -1323,7 +1335,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                   >
-                    {t('common.actions.delete')}
+                    <Icon name="close" size={24} />
                   </Button>
                 </div>
 
@@ -1342,6 +1354,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={certification.name.length > 0}
+                    theme="bg"
                   />
                   <DatePicker
                     type="month"
@@ -1378,6 +1391,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={Boolean(certification.institutionName)}
+                    theme="bg"
                   />
                 </div>
 
@@ -1400,6 +1414,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={Boolean(certification.description)}
+                    theme="bg"
                   />
                 </div>
               </div>
@@ -1440,7 +1455,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                   >
-                    {t('common.actions.delete')}
+                    <Icon name="close" size={24} />
                   </Button>
                 </div>
 
@@ -1459,6 +1474,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={language.language.length > 0}
+                    theme="bg"
                   />
                   <FormDropdown
                     value={language.proficiency}
@@ -1495,6 +1511,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={Boolean(language.testName)}
+                    theme="bg"
                   />
                   <FormInput
                     placeholder={t('form.scoreOptional')}
@@ -1513,6 +1530,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={Boolean(language.testScore)}
+                    theme="bg"
                   />
                 </div>
               </div>
@@ -1567,7 +1585,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                   >
-                    {t('common.actions.delete')}
+                    <Icon name="close" size={24} />
                   </Button>
                 </div>
 
@@ -1586,6 +1604,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={url.label.length > 0}
+                    theme="bg"
                   />
                   <FormInput
                     placeholder={t('form.url')}
@@ -1601,6 +1620,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                     filled={url.url.length > 0}
+                    theme="bg"
                   />
                 </div>
               </div>

--- a/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
+++ b/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
@@ -191,8 +191,10 @@ const EMPTY_URL: Omit<DraftUrl, 'id'> = {
   url: '',
 };
 
-const BASE_SECTION_CLASS = 'w-full rounded-[20px] px-[40px] py-[20px]';
-const BASIC_SECTION_CLASS = `${BASE_SECTION_CLASS} bg-white`;
+const BASE_SECTION_CLASS = 'w-full rounded-[20px] px-[20px]';
+const BASIC_SECTION_CLASS =
+  'w-full rounded-[20px] bg-white px-[40px] py-[20px]';
+const TOP_PADDED_SECTION_CLASS = `${BASE_SECTION_CLASS} pt-[20px]`;
 
 const CORE_EDUCATION_ORDER = [
   'vet_elementary',
@@ -221,17 +223,19 @@ function SectionHeader({
   addAriaLabel?: string;
 }) {
   return (
-    <div className="flex flex-col gap-[10px]">
-      <div className="flex items-start justify-between">
+    <div className="flex h-[43px] flex-col justify-center gap-[10px]">
+      <div className="flex items-center justify-between">
         <h2 className="text-h2 text-text-title-2">{title}</h2>
         {onAdd && (
           <button
             type="button"
             onClick={onAdd}
-            className="flex size-[42px] items-center justify-center"
+            className="flex size-[32px] items-center justify-center"
             aria-label={addAriaLabel ?? title}
           >
-            <span className="text-title text-text-title-2">+</span>
+            <span className="text-[30px] leading-[1.5] text-text-title-2">
+              +
+            </span>
           </button>
         )}
       </div>
@@ -698,23 +702,26 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
 
   return (
     <>
-      <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-[40px] px-6 py-10 pb-[140px]">
+      <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-[40px] px-4 pt-[80px] pb-[120px] md:px-6 lg:px-0">
         <section className={BASIC_SECTION_CLASS}>
           <h2 className="text-h2 text-text-title-2">
             {t('profile.basicProfile')}
           </h2>
 
-          <div className="mt-[25px] flex flex-col gap-6 lg:flex-row lg:items-start">
-            <div className="flex flex-col items-center gap-4">
-              <div className="flex h-48 w-48 items-center justify-center rounded-full bg-brand-sub">
+          <div className="mt-[25px] flex flex-col gap-[25px] lg:flex-row lg:items-center">
+            <div className="flex shrink-0 items-center justify-center">
+              <div className="flex h-[200px] w-[200px] items-center justify-center rounded-full bg-brand-sub">
                 <Icon
                   name="profile"
                   size={96}
                   alt={t('profile.image.placeholderAlt')}
                 />
               </div>
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-text-title-2">
+            </div>
+
+            <div className="flex flex-1 flex-col gap-[20px]">
+              <div className="flex items-center justify-start gap-[7px]">
+                <span className="text-caption-1 text-text-title-2">
                   {t('profile.hiringStatus')}
                 </span>
                 <ToggleSwitch
@@ -724,10 +731,8 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                   }
                 />
               </div>
-            </div>
 
-            <div className="flex flex-1 flex-col gap-5">
-              <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+              <div className="grid grid-cols-1 gap-[20px] md:grid-cols-2">
                 <FormInput
                   required
                   placeholder={t('form.firstName')}
@@ -750,8 +755,8 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                 />
               </div>
 
-              <div className="flex items-center gap-3">
-                <span className="text-sm font-medium text-text-title-2">
+              <div className="flex items-center gap-[10px]">
+                <span className="text-caption-1 text-text-title-2">
                   {t('form.dateOfBirth')}
                 </span>
                 <DatePicker
@@ -773,8 +778,8 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                 )}
               </div>
 
-              <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
-                <div className="flex items-center gap-2 rounded-[10px] bg-bg px-3 py-2">
+              <div className="grid grid-cols-1 gap-[20px] md:grid-cols-2">
+                <div className="flex items-center gap-[10px]">
                   <Icon name="mobile" size={20} />
                   <DialcodePicker
                     value={draft.contact.dialCode}
@@ -793,7 +798,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                   />
                 </div>
 
-                <div className="flex items-center gap-2 rounded-[10px] bg-bg px-3 py-2">
+                <div className="flex items-center gap-[10px]">
                   <Icon name="mail" size={20} />
                   <FormInput
                     className="h-11"
@@ -807,7 +812,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                 </div>
               </div>
 
-              <div className="flex items-center gap-2 rounded-[10px] bg-bg px-3 py-2">
+              <div className="flex items-center gap-[10px]">
                 <Icon name="location" size={20} />
                 <FormInput
                   required
@@ -865,44 +870,48 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
             }
           />
 
-          <div className="mt-[25px] flex flex-col gap-6">
+          <div className="mt-[25px] flex flex-col gap-[25px]">
             {draft.educations.map((education) => (
-              <div key={education.id} className="rounded-[10px] border p-4">
-                <div className="mb-3 flex justify-end">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() =>
-                      setDraft((prev) => ({
-                        ...prev,
-                        educations: prev.educations.filter(
-                          (item) => item.id !== education.id
-                        ),
-                      }))
-                    }
-                  >
-                    <Icon name="close" size={24} />
-                  </Button>
-                </div>
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                  <FormInput
-                    required
-                    placeholder={t('form.schoolName')}
-                    value={education.institutionName}
-                    onChange={(event) =>
-                      setDraft((prev) => ({
-                        ...prev,
-                        educations: prev.educations.map((item) =>
-                          item.id === education.id
-                            ? { ...item, institutionName: event.target.value }
-                            : item
-                        ),
-                      }))
-                    }
-                    filled={education.institutionName.length > 0}
-                    theme="bg"
-                  />
+              <div
+                key={education.id}
+                className="relative rounded-[20px] border-2 border-brand-sub p-[20px]"
+              >
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="absolute top-[18px] right-[20px]"
+                  onClick={() =>
+                    setDraft((prev) => ({
+                      ...prev,
+                      educations: prev.educations.filter(
+                        (item) => item.id !== education.id
+                      ),
+                    }))
+                  }
+                >
+                  <Icon name="close" size={24} />
+                </Button>
+
+                <FormInput
+                  required
+                  placeholder={t('form.schoolName')}
+                  value={education.institutionName}
+                  onChange={(event) =>
+                    setDraft((prev) => ({
+                      ...prev,
+                      educations: prev.educations.map((item) =>
+                        item.id === education.id
+                          ? { ...item, institutionName: event.target.value }
+                          : item
+                      ),
+                    }))
+                  }
+                  filled={education.institutionName.length > 0}
+                  theme="bg"
+                />
+
+                <div className="mt-[25px] grid grid-cols-1 gap-[25px] lg:grid-cols-[400px_1fr]">
                   <FormDropdown
                     value={education.educationType}
                     placeholder={t('form.levelOfEducation')}
@@ -918,9 +927,6 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                   />
-                </div>
-
-                <div className="mt-4">
                   <FormInput
                     placeholder={t('form.fieldOfStudyOptional')}
                     value={education.field ?? ''}
@@ -942,76 +948,79 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                   />
                 </div>
 
-                <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-[1fr_1fr_1fr]">
-                  <div className="flex items-center gap-2">
-                    <DatePicker
-                      type="month"
-                      value={fromDateString(education.startDate)}
-                      onChange={(date) =>
-                        setDraft((prev) => ({
-                          ...prev,
-                          educations: prev.educations.map((item) =>
-                            item.id === education.id
-                              ? { ...item, startDate: toDateString(date) }
-                              : item
-                          ),
-                        }))
-                      }
-                    />
-                    {education.startDate && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() =>
+                <div className="mt-[25px] grid grid-cols-1 gap-[25px] xl:grid-cols-[430px_1fr]">
+                  <div className="flex items-center gap-[10px]">
+                    <div className="flex items-center gap-2">
+                      <DatePicker
+                        type="month"
+                        value={fromDateString(education.startDate)}
+                        onChange={(date) =>
                           setDraft((prev) => ({
                             ...prev,
                             educations: prev.educations.map((item) =>
                               item.id === education.id
-                                ? { ...item, startDate: '' }
+                                ? { ...item, startDate: toDateString(date) }
                                 : item
                             ),
                           }))
                         }
-                      >
-                        {t('common.actions.clear')}
-                      </Button>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <DatePicker
-                      type="month"
-                      value={fromDateString(education.endDate)}
-                      onChange={(date) =>
-                        setDraft((prev) => ({
-                          ...prev,
-                          educations: prev.educations.map((item) =>
-                            item.id === education.id
-                              ? { ...item, endDate: toDateString(date) }
-                              : item
-                          ),
-                        }))
-                      }
-                    />
-                    {education.endDate && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        onClick={() =>
+                      />
+                      {education.startDate && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() =>
+                            setDraft((prev) => ({
+                              ...prev,
+                              educations: prev.educations.map((item) =>
+                                item.id === education.id
+                                  ? { ...item, startDate: '' }
+                                  : item
+                              ),
+                            }))
+                          }
+                        >
+                          {t('common.actions.clear')}
+                        </Button>
+                      )}
+                    </div>
+                    <span className="text-text-sub-2">-</span>
+                    <div className="flex items-center gap-2">
+                      <DatePicker
+                        type="month"
+                        value={fromDateString(education.endDate)}
+                        onChange={(date) =>
                           setDraft((prev) => ({
                             ...prev,
                             educations: prev.educations.map((item) =>
                               item.id === education.id
-                                ? { ...item, endDate: undefined }
+                                ? { ...item, endDate: toDateString(date) }
                                 : item
                             ),
                           }))
                         }
-                      >
-                        {t('common.actions.clear')}
-                      </Button>
-                    )}
+                      />
+                      {education.endDate && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() =>
+                            setDraft((prev) => ({
+                              ...prev,
+                              educations: prev.educations.map((item) =>
+                                item.id === education.id
+                                  ? { ...item, endDate: undefined }
+                                  : item
+                              ),
+                            }))
+                          }
+                        >
+                          {t('common.actions.clear')}
+                        </Button>
+                      )}
+                    </div>
                   </div>
                   <FormDropdown
                     value={education.graduationStatus}
@@ -1089,7 +1098,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
           </div>
         </section>
 
-        <section className={BASE_SECTION_CLASS}>
+        <section className={TOP_PADDED_SECTION_CLASS}>
           <SectionHeader
             title={t('profile.experience')}
             addAriaLabel={t('profile.actions.addAria', {
@@ -1105,28 +1114,27 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
               }))
             }
           />
-          <div className="mt-[25px] flex flex-col gap-6">
+          <div className="mt-[25px] flex flex-col gap-[25px]">
             {draft.careers.map((career) => (
-              <div key={career.id} className="rounded-[10px] border p-4">
-                <div className="mb-3 flex justify-end">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() =>
-                      setDraft((prev) => ({
-                        ...prev,
-                        careers: prev.careers.filter(
-                          (item) => item.id !== career.id
-                        ),
-                      }))
-                    }
-                  >
-                    <Icon name="close" size={24} />
-                  </Button>
-                </div>
+              <div key={career.id} className="relative rounded-[20px] p-[20px]">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="absolute top-[18px] right-[20px]"
+                  onClick={() =>
+                    setDraft((prev) => ({
+                      ...prev,
+                      careers: prev.careers.filter(
+                        (item) => item.id !== career.id
+                      ),
+                    }))
+                  }
+                >
+                  <Icon name="close" size={24} />
+                </Button>
 
-                <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_auto]">
+                <div className="grid grid-cols-1 gap-[25px]">
                   <FormInput
                     placeholder={t('form.companyName')}
                     value={career.companyName}
@@ -1143,7 +1151,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                     filled={career.companyName.length > 0}
                     theme="bg"
                   />
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-[10px]">
                     <DatePicker
                       type="month"
                       value={fromDateString(career.startDate)}
@@ -1158,6 +1166,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                         }))
                       }
                     />
+                    <span className="text-text-sub-2">-</span>
                     <DatePicker
                       type="month"
                       value={fromDateString(career.endDate)}
@@ -1172,10 +1181,27 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                         }))
                       }
                     />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        setDraft((prev) => ({
+                          ...prev,
+                          careers: prev.careers.map((item) =>
+                            item.id === career.id
+                              ? { ...item, endDate: undefined }
+                              : item
+                          ),
+                        }))
+                      }
+                    >
+                      {t('profile.actions.clearEndDate')}
+                    </Button>
                   </div>
                 </div>
 
-                <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-3">
+                <div className="mt-[25px] grid grid-cols-1 gap-[20px] lg:grid-cols-3">
                   <FormInput
                     placeholder={t('form.jobRole')}
                     value={career.positionTitle}
@@ -1240,7 +1266,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                   />
                 </div>
 
-                <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <div className="mt-[25px] grid grid-cols-1 gap-[20px] lg:grid-cols-2">
                   <FormDropdown
                     value={career.employmentType}
                     placeholder={t('form.employmentType')}
@@ -1256,26 +1282,9 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                       }))
                     }
                   />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() =>
-                      setDraft((prev) => ({
-                        ...prev,
-                        careers: prev.careers.map((item) =>
-                          item.id === career.id
-                            ? { ...item, endDate: undefined }
-                            : item
-                        ),
-                      }))
-                    }
-                  >
-                    {t('profile.actions.clearEndDate')}
-                  </Button>
                 </div>
 
-                <div className="mt-4">
+                <div className="mt-[25px]">
                   <FormInput
                     size="lg"
                     placeholder={t('form.descriptionOptional')}
@@ -1318,28 +1327,30 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
               }))
             }
           />
-          <div className="mt-[25px] flex flex-col gap-6">
+          <div className="mt-[25px] flex flex-col gap-[25px]">
             {draft.certifications.map((certification) => (
-              <div key={certification.id} className="rounded-[10px] border p-4">
-                <div className="mb-3 flex justify-end">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() =>
-                      setDraft((prev) => ({
-                        ...prev,
-                        certifications: prev.certifications.filter(
-                          (item) => item.id !== certification.id
-                        ),
-                      }))
-                    }
-                  >
-                    <Icon name="close" size={24} />
-                  </Button>
-                </div>
+              <div
+                key={certification.id}
+                className="relative rounded-[20px] p-[20px]"
+              >
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="absolute top-[18px] right-[20px]"
+                  onClick={() =>
+                    setDraft((prev) => ({
+                      ...prev,
+                      certifications: prev.certifications.filter(
+                        (item) => item.id !== certification.id
+                      ),
+                    }))
+                  }
+                >
+                  <Icon name="close" size={24} />
+                </Button>
 
-                <div className="grid grid-cols-1 gap-4 lg:grid-cols-[1fr_auto]">
+                <div className="grid grid-cols-1 gap-[20px] lg:grid-cols-[1fr_auto]">
                   <FormInput
                     placeholder={t('form.certification')}
                     value={certification.name}
@@ -1372,7 +1383,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                   />
                 </div>
 
-                <div className="mt-4">
+                <div className="mt-[25px]">
                   <FormInput
                     placeholder={t('form.institutionOptional')}
                     value={certification.institutionName ?? ''}
@@ -1395,7 +1406,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                   />
                 </div>
 
-                <div className="mt-4">
+                <div className="mt-[25px]">
                   <FormInput
                     size="lg"
                     placeholder={t('form.descriptionOptional')}
@@ -1438,28 +1449,30 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
               }))
             }
           />
-          <div className="mt-[25px] flex flex-col gap-6">
+          <div className="mt-[25px] flex flex-col gap-[25px]">
             {draft.languages.map((language) => (
-              <div key={language.id} className="rounded-[10px] border p-4">
-                <div className="mb-3 flex justify-end">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() =>
-                      setDraft((prev) => ({
-                        ...prev,
-                        languages: prev.languages.filter(
-                          (item) => item.id !== language.id
-                        ),
-                      }))
-                    }
-                  >
-                    <Icon name="close" size={24} />
-                  </Button>
-                </div>
+              <div
+                key={language.id}
+                className="relative rounded-[20px] p-[20px]"
+              >
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="absolute top-[18px] right-[20px]"
+                  onClick={() =>
+                    setDraft((prev) => ({
+                      ...prev,
+                      languages: prev.languages.filter(
+                        (item) => item.id !== language.id
+                      ),
+                    }))
+                  }
+                >
+                  <Icon name="close" size={24} />
+                </Button>
 
-                <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <div className="grid grid-cols-1 gap-[20px] lg:grid-cols-[1fr_300px]">
                   <FormInput
                     placeholder={t('form.language')}
                     value={language.language}
@@ -1493,7 +1506,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                   />
                 </div>
 
-                <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <div className="mt-[25px] grid grid-cols-1 gap-[20px] lg:grid-cols-2">
                   <FormInput
                     placeholder={t('form.testNameOptional')}
                     value={language.testName ?? ''}
@@ -1548,11 +1561,18 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
               <Icon name="plus" size={16} />
               {t('profile.upload.file')}
             </button>
-            <div className="flex items-center justify-between">
-              <p className="text-body-1 text-text-body-1">
-                {t('profile.upload.uploadedFile')}
-              </p>
-              <p className="text-body-2 text-text-sub-2">-</p>
+            <div className="flex items-center justify-between rounded-[20px] p-[20px]">
+              <div className="flex items-center gap-[10px]">
+                <Icon name="file" size={24} />
+                <p className="text-body-1 text-text-body-1">
+                  {t('profile.upload.uploadedFile')}
+                </p>
+                <div className="flex items-center gap-[10px]">
+                  <span className="h-[14px] w-px bg-text-sub-2" />
+                  <p className="text-body-3 text-text-sub-2">20MB</p>
+                </div>
+              </div>
+              <Icon name="close" size={24} />
             </div>
           </div>
         </section>
@@ -1570,26 +1590,25 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
               }))
             }
           />
-          <div className="mt-[25px] flex flex-col gap-6">
+          <div className="mt-[25px] flex flex-col gap-[25px]">
             {draft.urls.map((url) => (
-              <div key={url.id} className="rounded-[10px] border p-4">
-                <div className="mb-3 flex justify-end">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() =>
-                      setDraft((prev) => ({
-                        ...prev,
-                        urls: prev.urls.filter((item) => item.id !== url.id),
-                      }))
-                    }
-                  >
-                    <Icon name="close" size={24} />
-                  </Button>
-                </div>
+              <div key={url.id} className="relative rounded-[20px] p-[20px]">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="absolute top-[18px] right-[20px]"
+                  onClick={() =>
+                    setDraft((prev) => ({
+                      ...prev,
+                      urls: prev.urls.filter((item) => item.id !== url.id),
+                    }))
+                  }
+                >
+                  <Icon name="close" size={24} />
+                </Button>
 
-                <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                <div className="grid grid-cols-1 gap-[20px] lg:grid-cols-2">
                   <FormInput
                     placeholder={t('form.label')}
                     value={url.label}

--- a/frontend/features/profile-edit/ui/profile-public-form.tsx
+++ b/frontend/features/profile-edit/ui/profile-public-form.tsx
@@ -87,6 +87,7 @@ export function ProfilePublicForm({ initialData }: Props) {
                 onChange={(e) => field.handleChange(e.target.value)}
                 onBlur={field.handleBlur}
                 filled={field.state.value.length > 0}
+                theme="bg"
               />
               {field.state.meta.isTouched &&
                 field.state.meta.errors.length > 0 && (
@@ -108,6 +109,7 @@ export function ProfilePublicForm({ initialData }: Props) {
                 onChange={(e) => field.handleChange(e.target.value)}
                 onBlur={field.handleBlur}
                 filled={field.state.value.length > 0}
+                theme="bg"
               />
               {field.state.meta.isTouched &&
                 field.state.meta.errors.length > 0 && (
@@ -156,6 +158,7 @@ export function ProfilePublicForm({ initialData }: Props) {
                 onChange={(e) => field.handleChange(e.target.value)}
                 onBlur={field.handleBlur}
                 filled={Boolean(field.state.value)}
+                theme="bg"
               />
             </div>
           )}
@@ -172,6 +175,7 @@ export function ProfilePublicForm({ initialData }: Props) {
               onChange={(e) => field.handleChange(e.target.value)}
               onBlur={field.handleBlur}
               filled={Boolean(field.state.value)}
+              theme="bg"
             />
           </div>
         )}
@@ -188,6 +192,7 @@ export function ProfilePublicForm({ initialData }: Props) {
               onChange={(e) => field.handleChange(e.target.value)}
               onBlur={field.handleBlur}
               filled={Boolean(field.state.value)}
+              theme="bg"
             />
           </div>
         )}

--- a/shared/i18n/messages/en.ts
+++ b/shared/i18n/messages/en.ts
@@ -20,6 +20,8 @@ export const enMessages = {
   'common.actions.clear': 'Clear',
   'common.actions.close': 'Close',
   'common.actions.retry': 'Retry',
+  'common.actions.warnDirty':
+    'Any unsaved changes would be lost. Are you sure you want to quit?',
   'common.status.loading': 'Loading...',
 
   'analytics.consent.title': 'Help us improve your job search experience',

--- a/shared/i18n/messages/ko.ts
+++ b/shared/i18n/messages/ko.ts
@@ -17,6 +17,8 @@ export const koMessages: Record<MessageKey, string> = {
   'common.actions.clear': '비우기',
   'common.actions.close': '닫기',
   'common.actions.retry': '다시 시도',
+  'common.actions.warnDirty':
+    '저장되지 않은 변경사항이 있습니다. 페이지를 벗어나시겠습니까?',
   'common.status.loading': '로딩 중...',
 
   'analytics.consent.title': '더 나은 구직 경험을 위해 동의가 필요해요',

--- a/shared/i18n/messages/vi.ts
+++ b/shared/i18n/messages/vi.ts
@@ -18,6 +18,8 @@ export const viMessages: Record<MessageKey, string> = {
   'common.actions.clear': 'Xóa',
   'common.actions.close': 'Đóng',
   'common.actions.retry': 'Thử lại',
+  'common.actions.warnDirty':
+    'Có những thay đổi chưa được lưu. Bạn có chắc chắn muốn rời khỏi trang này không?',
   'common.status.loading': 'Đang tải...',
 
   'analytics.consent.title': 'Giúp chúng tôi cải thiện trải nghiệm tìm việc',


### PR DESCRIPTION
## 🔥 PR 제목

> fix(profile/edit): 프로필 수정 페이지 Figma 정합성 및 편집 상태 UI 개선

## ✨ 작업 내용

- 프로필 수정 페이지 레이아웃을 Figma 기준으로 재정렬했습니다. (섹션 간격/헤더/카드 패딩/버튼 배치)
- 수정 중인 영역에 `focus-within` 기반 border 피드백을 추가해 현재 편집 위치를 시각적으로 구분했습니다.
- `FormInput` 배경 테마 적용 및 삭제 액션 버튼 UI를 아이콘 중심으로 정리했습니다.
- 저장 전 화면 이탈 경고 문구를 다국어(en/ko/vi)로 적용하고 관련 테스트를 정리했습니다.
- 관련 이슈: #82

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

문서화 메모: N/A (동작/UI 정합성 수정으로 사용자 문서 변경 범위 없음)

## 🚀 테스트 방법

1. `pnpm -s exec eslint frontend/features/profile-edit/ui/profile-edit-page-client.tsx`
2. `pnpm -s exec tsc --noEmit --pretty false`

## 📸 스크린샷 / 시연 (선택)

N/A (브랜치에 스크린샷 산출물은 포함하지 않았습니다)

## 🙏 리뷰어에게 한마디

- UI 정합성 관련 변경이 많아 보일 수 있지만, 컴포넌트 API/비즈니스 로직 변경 없이 레이아웃/스타일 중심으로 조정했습니다.
- 특히 `profile-edit-page-client.tsx` 섹션별 카드 래퍼 클래스 변경을 중점으로 확인 부탁드립니다.
