### PR TITLE
docs(skill): 문서 거버넌스 스킬 도입 및 AGENTS 문서 정책 정리

### DIFF
--- a/.agents/skills/docs-governance/SKILL.md
+++ b/.agents/skills/docs-governance/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: docs-governance
+description: Keep repository documentation aligned with code changes and archive legacy docs safely. Use when editing files under `docs/`, deciding whether to move content into `docs/legacy/`, validating `docs/legacy` front matter (`archived_on`, `archive_reason`, `replaced_by`), or reconciling documentation scope after implementation work.
+---
+
+# Docs Governance
+
+## Purpose and Guardrails
+
+- Keep `docs/` and subfolders current with the codebase, except `docs/legacy/`.
+- Keep archival changes explicit, reversible, and traceable.
+- Preserve historical files in `docs/legacy/`; do not rewrite history unless content is factually wrong.
+- Keep policy-level rules in `AGENTS.md`; keep operational procedure in this skill and references.
+
+## Standard Workflow
+
+1. Identify changed code scope and enumerate impacted docs.
+2. Update active docs in `docs/` first.
+3. Decide archival status for superseded or non-operational documents.
+4. If archiving, move file under `docs/legacy/` while preserving filename and topical grouping.
+5. Add or validate required front matter for every legacy file.
+6. Run quick checks for policy coverage and archive metadata.
+7. Include docs verification output in issue/PR notes.
+
+Use `references/workflow.md` for the detailed command-level procedure.
+
+## Archive Decision Rules
+
+- Archive a document when it is superseded by a newer operational doc.
+- Archive a document when it is no longer operationally used.
+- Keep a document in active `docs/` when it is still an operational source of truth.
+- Use `archive_reason` values exactly:
+  - `superseded`
+  - `no_longer_operational`
+  - `historical_reference`
+
+Use `references/archive-frontmatter.md` for valid and invalid examples.
+
+## Front Matter Rule Enforcement
+
+For every file in `docs/legacy/`, require YAML front matter keys:
+
+- `archived_on`
+- `archive_reason`
+- `replaced_by`
+
+Enforce relation constraints:
+
+- `replaced_by` is required when `archive_reason: superseded`.
+- `replaced_by` is optional otherwise.
+
+Use `references/checklist.md` for verification commands and release handoff checks.
+
+## References
+
+- Detailed operational flow: `references/workflow.md`
+- Front matter schema and examples: `references/archive-frontmatter.md`
+- Pre-PR and handoff checks: `references/checklist.md`

--- a/.agents/skills/docs-governance/agents/openai.yaml
+++ b/.agents/skills/docs-governance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Docs Governance"
+  short_description: "Keep docs current and archive legacy safely"
+  default_prompt: "Use $docs-governance to update docs, archive legacy documents, and verify archive front matter rules."

--- a/.agents/skills/docs-governance/references/archive-frontmatter.md
+++ b/.agents/skills/docs-governance/references/archive-frontmatter.md
@@ -1,0 +1,52 @@
+# Legacy Front Matter Rules
+
+## Required Keys
+
+Every file under `docs/legacy/` must include YAML front matter with:
+
+- `archived_on`
+- `archive_reason`
+- `replaced_by`
+
+Allowed `archive_reason` values:
+
+- `superseded`
+- `no_longer_operational`
+- `historical_reference`
+
+## Conditional Constraint
+
+- If `archive_reason: superseded`, `replaced_by` must be a non-empty path.
+- For `no_longer_operational` and `historical_reference`, `replaced_by` may be null.
+
+## Valid Example: Superseded
+
+```yaml
+---
+archived_on: 2026-02-26
+archive_reason: superseded
+replaced_by: docs/project-state.md
+---
+```
+
+## Valid Example: Historical Reference
+
+```yaml
+---
+archived_on: 2026-02-26
+archive_reason: historical_reference
+replaced_by: null
+---
+```
+
+## Invalid Example: Missing Required Replacement
+
+```yaml
+---
+archived_on: 2026-02-26
+archive_reason: superseded
+replaced_by: null
+---
+```
+
+Reason: `replaced_by` cannot be null when `archive_reason` is `superseded`.

--- a/.agents/skills/docs-governance/references/checklist.md
+++ b/.agents/skills/docs-governance/references/checklist.md
@@ -1,0 +1,25 @@
+# Docs Governance Checklist
+
+## Pre-PR Checklist
+
+- [ ] Active docs in `docs/` reflect the current implementation.
+- [ ] No unrelated doc rewrites were introduced.
+- [ ] Legacy files retain original filenames and grouping.
+- [ ] Every `docs/legacy/` file has required front matter keys.
+- [ ] `replaced_by` is non-null when `archive_reason: superseded`.
+- [ ] `AGENTS.md` keeps hard policy constraints.
+- [ ] `$docs-governance` is documented in skill metadata and default prompt.
+
+## Verification Commands
+
+```bash
+PYTHONPATH=/tmp/codex-pyyaml python3 /Users/ori/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/docs-governance
+```
+
+```bash
+rg -n "docs-governance|archive_reason|replaced_by|docs/legacy" AGENTS.md .agents/skills/docs-governance/SKILL.md .agents/skills/docs-governance/references/*.md
+```
+
+```bash
+rg -n "^---$|archived_on|archive_reason|replaced_by" docs/legacy/*.md
+```

--- a/.agents/skills/docs-governance/references/workflow.md
+++ b/.agents/skills/docs-governance/references/workflow.md
@@ -1,0 +1,48 @@
+# Docs Governance Workflow
+
+## Goal
+
+Apply a consistent, low-risk process for documentation updates and legacy archiving.
+
+## Step-by-Step Procedure
+
+1. Map implementation scope to docs scope.
+- Read changed files and identify impacted docs sections.
+- Keep scope strict; do not rewrite unrelated docs.
+
+2. Update active docs.
+- Edit files under `docs/` (excluding `docs/legacy/`) to match current code behavior.
+- Remove stale instructions in active docs.
+
+3. Decide archive actions.
+- Choose archive only when a file is superseded or no longer operational.
+- Keep still-operational files in active `docs/`.
+
+4. Move files to legacy when needed.
+- Move to `docs/legacy/` without renaming the file.
+- Preserve topic grouping (subfolder structure) when applicable.
+
+5. Add or update legacy front matter.
+- Ensure required keys exist on every legacy file:
+  - `archived_on`
+  - `archive_reason`
+  - `replaced_by`
+- Apply conditional requirement for `replaced_by` when superseded.
+
+6. Run verification checks.
+- Validate skill metadata and policy wiring.
+- Validate legacy front matter coverage by grep-based checks.
+
+7. Record evidence in review artifacts.
+- Include commands and outputs in issue/PR descriptions.
+- Keep issue open until merge/completion.
+
+## Quick Commands
+
+```bash
+rg -n "docs-governance|archive_reason|replaced_by|docs/legacy" AGENTS.md .agents/skills/docs-governance/SKILL.md .agents/skills/docs-governance/references/*.md
+```
+
+```bash
+find docs/legacy -type f | sort
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,12 +151,11 @@ YOU MUST follow this debugging framework for ANY technical issue:
 - Exceptions: `AGENTS.md` and `docs/agents/*` must be written in English. Files under `docs/legacy/*` may remain in their original language.
 - `docs/` and its subfolders (except `docs/legacy/`) MUST be kept current with the codebase; do not leave outdated content after related changes.
 - `docs/legacy/` contains archived historical documents that may be outdated by design.
-- Move a document to `docs/legacy/` when it is superseded by a newer document OR no longer operationally used.
-- In `docs/legacy/`, preserve original filenames and relative topic grouping (do not add date prefixes to filenames).
-- Every document in `docs/legacy/` MUST include YAML front matter with keys: `archived_on`, `archive_reason`, `replaced_by`.
-- Allowed `archive_reason` values are: `superseded`, `no_longer_operational`, `historical_reference`.
-- `replaced_by` is required when `archive_reason: superseded`, and optional otherwise.
 - `docs/agents/` contains prompt plans and LLM-facing operational documents, and these files should be written in English.
+- Archive to `docs/legacy/` only when superseded or no longer operational, while preserving original filenames and relative topic grouping.
+- Every `docs/legacy/` document MUST include YAML front matter keys `archived_on`, `archive_reason`, and `replaced_by`; allowed `archive_reason` values are `superseded`, `no_longer_operational`, `historical_reference`.
+- `replaced_by` is required when `archive_reason: superseded`, and optional otherwise.
+- Use `$docs-governance` for docs update/archive procedure and verification checks.
 
 ## Sandboxing
 


### PR DESCRIPTION
## 🔥 PR 제목

docs(skill): 문서 거버넌스 스킬 도입 및 AGENTS 문서 정책 정리

## ✨ 작업 내용

- repo-local 스킬 `.agents/skills/docs-governance` 추가
- `SKILL.md`에 트리거/가드레일/운영 워크플로우 정의
- 참조 문서 3종 추가
  - `references/workflow.md`
  - `references/archive-frontmatter.md`
  - `references/checklist.md`
- `AGENTS.md`의 Documentation Guidelines를 핵심 정책 중심으로 경량화
- `$docs-governance` 사용 지시 라인 추가
- 관련 이슈: #84

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- `PYTHONPATH=/tmp/codex-pyyaml python3 /Users/ori/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/docs-governance`
  - 결과: `Skill is valid!`
- `rg -n "docs-governance|archive_reason|replaced_by|docs/legacy" AGENTS.md .agents/skills/docs-governance/SKILL.md .agents/skills/docs-governance/references/*.md`
  - 결과: 정책/스킬/참조 문서의 키워드 매핑 확인

## 📸 스크린샷 / 시연 (선택)

N/A (문서/스킬 구성 변경)

## 🙏 리뷰어에게 한마디

`AGENTS.md`에는 강제 정책만 남기고, 절차성 내용은 재사용 가능한 스킬로 이동했습니다. 이후 문서 갱신/아카이브 작업 시 `$docs-governance` 호출을 기준 워크플로우로 사용하면 됩니다.
