### PR TITLE
fix(UI): 프로필 편집 Figma 정합성 개선 및 headline 제거

### DIFF
--- a/__tests__/app/candidate-profile-edit-page.test.tsx
+++ b/__tests__/app/candidate-profile-edit-page.test.tsx
@@ -46,7 +46,6 @@ const profileData = {
     aboutMe: 'Designing intuitive products',
     dateOfBirth: new Date('2000-02-10T00:00:00.000Z'),
     location: 'Ho Chi Minh City',
-    headline: 'Product Designer',
     isOpenToWork: true,
     profileImageUrl: null,
     isPublic: true,

--- a/__tests__/app/candidate-profile-page.test.tsx
+++ b/__tests__/app/candidate-profile-page.test.tsx
@@ -34,7 +34,6 @@ const profileData = {
     lastName: 'Park',
     dateOfBirth: new Date('2000-02-10T00:00:00.000Z'),
     location: 'Ho Chi Minh City',
-    headline: 'Product Designer',
     aboutMe: 'Designing intuitive products',
     isOpenToWork: true,
     profileImageUrl: null,

--- a/__tests__/app/candidate-slug-page.test.tsx
+++ b/__tests__/app/candidate-slug-page.test.tsx
@@ -52,7 +52,6 @@ const profileData = {
     lastName: 'Park',
     dateOfBirth: new Date('2000-02-10T00:00:00.000Z'),
     location: 'Ho Chi Minh City',
-    headline: 'Product Designer',
     aboutMe: '소개',
     isOpenToWork: true,
     profileImageUrl: null,

--- a/__tests__/components/ui/date-picker.test.tsx
+++ b/__tests__/components/ui/date-picker.test.tsx
@@ -21,12 +21,12 @@ describe('DatePicker', () => {
     expect(trigger).toHaveClass('rounded-[10px]');
   });
 
-  it('값이 있을 때 filled 스타일: bg-white + border', () => {
+  it('값이 있을 때 filled 스타일: bg-bg + border', () => {
     renderWithI18n(
       <DatePicker value={new Date(Date.UTC(2024, 5, 15))} onChange={() => {}} />
     );
     const trigger = screen.getByRole('button');
-    expect(trigger).toHaveClass('bg-white');
+    expect(trigger).toHaveClass('bg-bg');
     expect(trigger).toHaveClass('border-gray-300');
   });
 

--- a/__tests__/components/ui/form-input.test.tsx
+++ b/__tests__/components/ui/form-input.test.tsx
@@ -3,23 +3,23 @@ import { FormInput } from '@/frontend/components/ui/form-input';
 import { renderWithI18n } from '@/__tests__/test-utils/render-with-i18n';
 
 describe('FormInput', () => {
-  it('sm 사이즈: h-[41px]', () => {
+  it('sm 사이즈: h-input-h-sm', () => {
     renderWithI18n(<FormInput size="sm" placeholder="Name" />);
     const input = screen.getByPlaceholderText('Name');
-    expect(input).toHaveClass('h-[41px]');
+    expect(input).toHaveClass('h-input-h-sm');
   });
 
-  it('md 사이즈 (기본): h-[52px]', () => {
+  it('md 사이즈 (기본): h-input-h-md', () => {
     renderWithI18n(<FormInput placeholder="Email" />);
     const input = screen.getByPlaceholderText('Email');
-    expect(input).toHaveClass('h-[52px]');
+    expect(input).toHaveClass('h-input-h-md');
   });
 
   it('lg 사이즈: textarea 렌더링', () => {
     renderWithI18n(<FormInput size="lg" placeholder="Bio" />);
     const textarea = screen.getByPlaceholderText('Bio');
     expect(textarea.tagName).toBe('TEXTAREA');
-    expect(textarea).toHaveClass('h-[130px]');
+    expect(textarea).toHaveClass('h-input-h-lg');
   });
 
   it('기본 상태: white 배경', () => {

--- a/__tests__/entities/profile/profile-card.test.tsx
+++ b/__tests__/entities/profile/profile-card.test.tsx
@@ -9,7 +9,6 @@ const baseProps = {
   phone: '+82 10-1234-5678',
   email: 'john@example.com',
   location: 'Seoul',
-  headline: 'Experienced developer looking for new opportunities',
   aboutMe: 'Building reliable web products',
 };
 
@@ -31,16 +30,6 @@ describe('ProfileCard', () => {
     const summary = screen.getByText('Building reliable web products');
     expect(summary).toBeInTheDocument();
     expect(summary).toHaveClass('text-body-1');
-    expect(
-      screen.queryByText('Experienced developer looking for new opportunities')
-    ).not.toBeInTheDocument();
-  });
-
-  it('aboutMe가 없으면 headline을 요약으로 사용한다', () => {
-    renderWithI18n(<ProfileCard {...baseProps} aboutMe={null} />);
-    expect(
-      screen.getByText('Experienced developer looking for new opportunities')
-    ).toBeInTheDocument();
   });
 
   it('isOpenToWork=true 이면 recruiting 상태 표시', () => {

--- a/__tests__/features/profile-edit/profile-public-form.test.tsx
+++ b/__tests__/features/profile-edit/profile-public-form.test.tsx
@@ -33,7 +33,6 @@ describe('ProfilePublicForm', () => {
           aboutMe: '소개',
           dateOfBirth: '1990-01-15',
           location: 'Seoul',
-          headline: 'Frontend Engineer',
           isOpenToWork: true,
         }}
       />
@@ -42,7 +41,6 @@ describe('ProfilePublicForm', () => {
     expect(screen.getByLabelText(/First Name/i)).toHaveValue('길동');
     expect(screen.getByLabelText(/Last Name/i)).toHaveValue('홍');
     expect(screen.getByLabelText(/Location/i)).toHaveValue('Seoul');
-    expect(screen.getByLabelText(/Headline/i)).toHaveValue('Frontend Engineer');
     expect(screen.getByLabelText(/About Me/i)).toHaveValue('소개');
     expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
   });

--- a/__tests__/lib/validations/profile.test.ts
+++ b/__tests__/lib/validations/profile.test.ts
@@ -65,15 +65,6 @@ describe('profilePublicSchema', () => {
       }).success
     ).toBe(false);
   });
-  it('headline 200자 초과 거부', () => {
-    expect(
-      profilePublicSchema.safeParse({
-        firstName: 'A',
-        lastName: 'B',
-        headline: 'x'.repeat(201),
-      }).success
-    ).toBe(false);
-  });
   it('isOpenToWork boolean 통과', () => {
     expect(
       profilePublicSchema.safeParse({

--- a/app/(dashboard)/candidate/profile/edit/page.tsx
+++ b/app/(dashboard)/candidate/profile/edit/page.tsx
@@ -87,7 +87,6 @@ export default async function CandidateProfileEditPage() {
                 ? profilePublic.dateOfBirth.toISOString().split('T')[0]
                 : undefined,
               location: profilePublic.location,
-              headline: profilePublic.headline,
               isOpenToWork: profilePublic.isOpenToWork,
             }
           : undefined

--- a/app/(dashboard)/candidate/profile/profile-content.tsx
+++ b/app/(dashboard)/candidate/profile/profile-content.tsx
@@ -17,7 +17,6 @@ type ProfilePublic = {
   lastName: string;
   dateOfBirth: Date | null;
   location: string | null;
-  headline: string | null;
   aboutMe: string | null;
   isOpenToWork: boolean;
   profileImageUrl: string | null;
@@ -184,9 +183,7 @@ function BasicProfileCard({
 }) {
   const firstName = profilePublic?.firstName ?? '';
   const lastName = profilePublic?.lastName ?? '';
-  const summary =
-    normalizeText(profilePublic?.aboutMe) ??
-    normalizeText(profilePublic?.headline);
+  const summary = normalizeText(profilePublic?.aboutMe);
 
   return (
     <section className={`${CARD_CLASS} flex flex-col gap-[25px]`}>

--- a/app/candidate/[slug]/page.tsx
+++ b/app/candidate/[slug]/page.tsx
@@ -53,7 +53,6 @@ export default async function CandidateLandingPage({
           dateOfBirth={profilePublic?.dateOfBirth ?? undefined}
           email={authUser?.email}
           location={profilePublic?.location}
-          headline={profilePublic?.headline}
           aboutMe={profilePublic?.aboutMe}
           isOpenToWork={profilePublic?.isOpenToWork ?? false}
           profileImageUrl={profilePublic?.profileImageUrl}

--- a/app/candidate/[slug]/profile/page.tsx
+++ b/app/candidate/[slug]/profile/page.tsx
@@ -50,7 +50,6 @@ export default async function CandidatePublicProfilePage({
             dateOfBirth={profilePublic?.dateOfBirth ?? undefined}
             email={authUser?.email}
             location={profilePublic?.location}
-            headline={profilePublic?.headline}
             aboutMe={profilePublic?.aboutMe}
             isOpenToWork={profilePublic?.isOpenToWork ?? false}
             profileImageUrl={profilePublic?.profileImageUrl}

--- a/app/globals.css
+++ b/app/globals.css
@@ -133,6 +133,9 @@
   --text-display--font-weight: 700;
 
   /* Size Themes */
+  --spacing-input-h-sm: 44px;
+  --spacing-input-h-md: 52px;
+  --spacing-input-h-lg: 130px;
 }
 
 @custom-variant dark (&:is(.dark *));

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,7 @@
 @import 'shadcn/tailwind.css';
 
 @theme {
+  /* Color Themes */
   --color-*: initial;
 
   --color-orange-50: #ffdfcc;
@@ -74,7 +75,7 @@
   --color-error: var(--color-red-500);
   --color-success: var(--color-green-600);
   --color-info: var(--color-blue-500);
-  --color-bg: #fbfbfb;
+  --color-bg: #f7f7f7;
   --color-border: #b3b3b3;
 
   --color-text-title-1: var(--color-black);
@@ -85,6 +86,7 @@
   --color-text-sub-2: var(--color-gray-500);
   --color-text-info: var(--color-gray-400);
 
+  /* Text Themes */
   --text-title: 1.875rem;
   --text-title--line-height: 1.5;
   --text-title--font-weight: 700;
@@ -129,6 +131,8 @@
   --text-display: 4.5rem;
   --text-display--line-height: 1;
   --text-display--font-weight: 700;
+
+  /* Size Themes */
 }
 
 @custom-variant dark (&:is(.dark *));

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -108,6 +108,7 @@ export default async function JobsPage({
               href={`/jobs/${jd.id}`}
               cta={
                 <JobsListApplyCta
+                  key={jd.id}
                   jdId={jd.id}
                   status={jd.status}
                   isAuthenticated={isAuthenticated}

--- a/backend/prisma/migrations/20260226000000_remove_profile_headline/migration.sql
+++ b/backend/prisma/migrations/20260226000000_remove_profile_headline/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "profiles_public"
+DROP COLUMN "headline";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -230,7 +230,6 @@ model ProfilesPublic {
   publicSlug String  @unique @map("public_slug") @db.Text @default(dbgenerated("generate_profile_slug()"))
   dateOfBirth     DateTime? @map("date_of_birth") @db.Date
   location        String?
-  headline        String?
   isOpenToWork    Boolean   @default(false) @map("is_open_to_work")
   profileImageUrl String?   @map("profile_image_url")
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz

--- a/backend/prisma/seed-builders.ts
+++ b/backend/prisma/seed-builders.ts
@@ -56,7 +56,6 @@ export interface SampleProfileSeed {
     isOpenToWork?: boolean;
     dateOfBirth?: string;
     location?: string;
-    headline?: string;
     profileImageUrl?: string;
   };
   private: {
@@ -207,7 +206,6 @@ export function buildCanonicalUsers(params: {
           isOpenToWork: true,
           dateOfBirth: '1996-03-07',
           location: 'Seoul',
-          headline: 'Frontend Engineer',
         },
         private: {
           phoneNumber: '+82-10-5555-0101',
@@ -419,7 +417,6 @@ export function buildGeneratedUsers(
               ? `199${index % 10}-0${(index % 8) + 1}-1${index % 9}`
               : undefined,
           location: index % 2 === 0 ? 'Seoul' : 'Ho Chi Minh City',
-          headline: `Candidate Track ${n}`,
         },
         private: {
           phoneNumber: `+84-90-55${phoneSuffix}`,

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -558,7 +558,6 @@ async function seedSampleUsers(users: SampleUserSeed[]) {
           ? toDateOnlyUtc(user.profile.public.dateOfBirth)
           : null,
         location: user.profile.public.location ?? null,
-        headline: user.profile.public.headline ?? null,
         isOpenToWork: user.profile.public.isOpenToWork ?? false,
         profileImageUrl: user.profile.public.profileImageUrl ?? null,
       },
@@ -572,7 +571,6 @@ async function seedSampleUsers(users: SampleUserSeed[]) {
           ? toDateOnlyUtc(user.profile.public.dateOfBirth)
           : null,
         location: user.profile.public.location ?? null,
-        headline: user.profile.public.headline ?? null,
         isOpenToWork: user.profile.public.isOpenToWork ?? false,
         profileImageUrl: user.profile.public.profileImageUrl ?? null,
       },

--- a/backend/validations/profile.ts
+++ b/backend/validations/profile.ts
@@ -6,7 +6,6 @@ export const profilePublicSchema = z.object({
   aboutMe: z.string().max(2000).optional(),
   dateOfBirth: z.string().date().optional(),
   location: z.string().max(200).optional(),
-  headline: z.string().max(200).optional(),
   isOpenToWork: z.boolean().optional(),
 });
 

--- a/frontend/components/ui/date-picker.tsx
+++ b/frontend/components/ui/date-picker.tsx
@@ -119,10 +119,8 @@ export function DatePicker({
     <div ref={ref} className="relative">
       <button
         type="button"
-        className={`flex h-[52px] items-center justify-between rounded-[10px] px-[20px] text-left ${triggerWidthClass} ${
-          hasValue
-            ? 'border border-gray-300 bg-white text-gray-800'
-            : 'bg-bg text-gray-600'
+        className={`flex h-[52px] items-center justify-between rounded-[10px] bg-bg px-[20px] text-left ${triggerWidthClass} ${
+          hasValue ? 'border border-gray-300 text-gray-800' : 'text-gray-600'
         }`}
         onClick={() => setOpen(!open)}
         aria-expanded={open}

--- a/frontend/components/ui/date-picker.tsx
+++ b/frontend/components/ui/date-picker.tsx
@@ -39,13 +39,40 @@ function ScrollColumn({
   widthClass: string;
   format?: (v: number) => string;
 }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const selectedItemRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const selectedItem = selectedItemRef.current;
+
+    if (!container || !selectedItem) {
+      return;
+    }
+
+    const centeredScrollTop =
+      selectedItem.offsetTop -
+      container.clientHeight / 2 +
+      selectedItem.clientHeight / 2;
+    const nextScrollTop = Math.max(0, centeredScrollTop);
+
+    if (typeof container.scrollTo === 'function') {
+      container.scrollTo({ top: nextScrollTop });
+      return;
+    }
+
+    container.scrollTop = nextScrollTop;
+  }, [selected]);
+
   return (
     <div
+      ref={containerRef}
       className={`scroll scrollbar-thin flex h-[194px] flex-col gap-[10px] overflow-y-auto ${widthClass}`}
     >
       {items.map((item) => (
         <button
           key={item}
+          ref={item === selected ? selectedItemRef : null}
           type="button"
           className={`flex h-[41px] w-full items-center justify-center rounded-[5px] px-[10px] text-center text-caption-1 ${
             item === selected

--- a/frontend/components/ui/dialcode-picker.tsx
+++ b/frontend/components/ui/dialcode-picker.tsx
@@ -32,7 +32,7 @@ export function DialcodePicker({ value, onChange }: DialcodePickerProps) {
     <div ref={ref} className="relative">
       <button
         type="button"
-        className="flex h-[44px] w-[92px] items-center justify-start gap-[5px] rounded-[10px] bg-bg px-3.5 py-2.5"
+        className="flex h-input-h-sm w-[92px] items-center justify-start gap-[5px] rounded-[10px] bg-bg px-3.5 py-2.5"
         onClick={() => setOpen(!open)}
         aria-expanded={open}
       >

--- a/frontend/components/ui/dialcode-picker.tsx
+++ b/frontend/components/ui/dialcode-picker.tsx
@@ -32,7 +32,7 @@ export function DialcodePicker({ value, onChange }: DialcodePickerProps) {
     <div ref={ref} className="relative">
       <button
         type="button"
-        className="flex h-[44px] items-center gap-[5px] rounded-[10px] bg-bg px-[15px] py-[10px]"
+        className="flex h-[44px] w-[92px] items-center justify-start gap-[5px] rounded-[10px] bg-bg px-3.5 py-2.5"
         onClick={() => setOpen(!open)}
         aria-expanded={open}
       >
@@ -45,7 +45,7 @@ export function DialcodePicker({ value, onChange }: DialcodePickerProps) {
         <Icon name={open ? 'chevron-up' : 'chevron-down'} size={18} />
       </button>
       {open && (
-        <div className="absolute top-[48px] left-0 z-10 w-[106px] rounded-[10px] bg-white px-[20px] py-[10px] shadow-[0_0_10px_rgba(0,0,0,0.05)]">
+        <div className="absolute top-[48px] left-0 z-10 w-[92px] rounded-[10px] bg-bg px-[20px] py-[10px] shadow-[0_0_10px_rgba(0,0,0,0.05)]">
           {DIAL_CODES.map((option) => (
             <button
               key={option.code}

--- a/frontend/components/ui/form-input.tsx
+++ b/frontend/components/ui/form-input.tsx
@@ -18,9 +18,9 @@ type FormInputProps = {
   Omit<ComponentPropsWithoutRef<'textarea'>, 'size'>;
 
 const SIZE_CLASS: Record<FormInputSize, string> = {
-  sm: 'h-[41px] px-[20px] py-[10px]',
-  md: 'h-[52px] px-[20px]',
-  lg: 'h-[130px] p-[20px]',
+  sm: 'h-input-h-sm px-[20px] py-[10px]',
+  md: 'h-input-h-md px-[20px]',
+  lg: 'h-input-h-lg p-[20px]',
 };
 
 const baseClass =

--- a/frontend/entities/profile/ui/profile-card.tsx
+++ b/frontend/entities/profile/ui/profile-card.tsx
@@ -13,7 +13,6 @@ type Props = {
   phone?: string | null;
   email?: string | null;
   location?: string | null;
-  headline?: string | null;
   aboutMe?: string | null;
   isOpenToWork?: boolean;
   profileImageUrl?: string | null;
@@ -44,7 +43,6 @@ export function ProfileCard({
   phone,
   email,
   location,
-  headline,
   aboutMe,
   isOpenToWork = false,
   profileImageUrl,
@@ -52,7 +50,7 @@ export function ProfileCard({
   statusAccessory,
 }: Props) {
   const { locale, t } = useI18n();
-  const summary = aboutMe?.trim() || headline?.trim();
+  const summary = aboutMe?.trim();
   const statusLabel = isOpenToWork
     ? t('profile.openToWork')
     : t('profile.notOpenToWork');

--- a/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
+++ b/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
@@ -786,7 +786,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                     onChange={(code) => updateDraftContact('dialCode', code)}
                   />
                   <FormInput
-                    className="h-11"
+                    size="sm"
                     required
                     placeholder={t('form.phoneNumber')}
                     value={draft.contact.phoneNumber}
@@ -801,7 +801,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                 <div className="flex items-center gap-[10px]">
                   <Icon name="mail" size={20} />
                   <FormInput
-                    className="h-11"
+                    size="sm"
                     placeholder={t('form.email')}
                     value={draft.contact.email}
                     filled
@@ -816,7 +816,7 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                 <Icon name="location" size={20} />
                 <FormInput
                   required
-                  className="h-11"
+                  size="sm"
                   placeholder={t('form.location')}
                   value={draft.public.location}
                   onChange={(event) =>

--- a/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
+++ b/frontend/features/profile-edit/ui/profile-edit-page-client.tsx
@@ -66,7 +66,6 @@ type DraftPublic = {
   aboutMe: string;
   dateOfBirth?: string;
   location: string;
-  headline: string;
   isOpenToWork: boolean;
 };
 
@@ -138,7 +137,6 @@ type ProfileEditPageClientProps = {
     aboutMe?: string | null;
     dateOfBirth?: string | null;
     location?: string | null;
-    headline?: string | null;
     isOpenToWork?: boolean | null;
   } | null;
   profilePrivate?: { phoneNumber?: string | null } | null;
@@ -293,7 +291,6 @@ function toComparableDraft(draft: ProfileEditDraft) {
       aboutMe: normalizeText(draft.public.aboutMe),
       dateOfBirth: draft.public.dateOfBirth || undefined,
       location: normalizeText(draft.public.location),
-      headline: normalizeText(draft.public.headline),
       isOpenToWork: Boolean(draft.public.isOpenToWork),
     },
     contact: {
@@ -359,7 +356,6 @@ function buildInitialDraft(
       aboutMe: props.profilePublic?.aboutMe ?? '',
       dateOfBirth: props.profilePublic?.dateOfBirth ?? undefined,
       location: props.profilePublic?.location ?? '',
-      headline: props.profilePublic?.headline ?? '',
       isOpenToWork: Boolean(props.profilePublic?.isOpenToWork),
     },
     contact: {
@@ -572,7 +568,6 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
           aboutMe: normalizeText(draft.public.aboutMe),
           dateOfBirth: draft.public.dateOfBirth || undefined,
           location: normalizeText(draft.public.location),
-          headline: normalizeText(draft.public.headline),
           isOpenToWork: Boolean(draft.public.isOpenToWork),
         });
       }
@@ -826,18 +821,6 @@ export function ProfileEditPageClient(props: ProfileEditPageClientProps) {
                   theme="bg"
                 />
               </div>
-
-              <FormInput
-                required
-                size="lg"
-                placeholder={t('form.headline')}
-                value={draft.public.headline}
-                onChange={(event) =>
-                  updateDraftPublic('headline', event.target.value)
-                }
-                filled={draft.public.headline.length > 0}
-                theme="bg"
-              />
 
               <FormInput
                 size="lg"

--- a/frontend/features/profile-edit/ui/profile-public-form.tsx
+++ b/frontend/features/profile-edit/ui/profile-public-form.tsx
@@ -20,7 +20,6 @@ type Props = {
     aboutMe?: string | null;
     dateOfBirth?: Date | string | null;
     location?: string | null;
-    headline?: string | null;
     isOpenToWork?: boolean;
   };
 };
@@ -52,7 +51,6 @@ export function ProfilePublicForm({ initialData }: Props) {
     aboutMe: initialData?.aboutMe ?? undefined,
     dateOfBirth: toDateString(initialData?.dateOfBirth),
     location: initialData?.location ?? undefined,
-    headline: initialData?.headline ?? undefined,
     isOpenToWork: initialData?.isOpenToWork ?? false,
   };
 
@@ -164,22 +162,6 @@ export function ProfilePublicForm({ initialData }: Props) {
           )}
         </form.Field>
       </div>
-
-      <form.Field name="headline">
-        {(field) => (
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="pub-headline">{t('form.headline')}</Label>
-            <FormInput
-              id="pub-headline"
-              value={field.state.value ?? ''}
-              onChange={(e) => field.handleChange(e.target.value)}
-              onBlur={field.handleBlur}
-              filled={Boolean(field.state.value)}
-              theme="bg"
-            />
-          </div>
-        )}
-      </form.Field>
 
       <form.Field name="aboutMe">
         {(field) => (

--- a/shared/i18n/messages/en.ts
+++ b/shared/i18n/messages/en.ts
@@ -205,7 +205,6 @@ export const enMessages = {
   'form.phoneNumber': 'Phone Number',
   'form.email': 'E-mail',
   'form.location': 'Location (Country/Region City,State)',
-  'form.headline': 'Headline',
   'form.aboutMe': 'About Me',
   'form.schoolName': 'School Name',
   'form.levelOfEducation': 'Level of Education',

--- a/shared/i18n/messages/ko.ts
+++ b/shared/i18n/messages/ko.ts
@@ -194,7 +194,6 @@ export const koMessages: Record<MessageKey, string> = {
   'form.phoneNumber': '연락처',
   'form.email': '이메일',
   'form.location': '지역 (국가/도시)',
-  'form.headline': '헤드라인',
   'form.aboutMe': '소개',
   'form.schoolName': '학교/기관명',
   'form.levelOfEducation': '학력 유형',

--- a/shared/i18n/messages/vi.ts
+++ b/shared/i18n/messages/vi.ts
@@ -202,7 +202,6 @@ export const viMessages: Record<MessageKey, string> = {
   'form.phoneNumber': 'Số điện thoại',
   'form.email': 'Email',
   'form.location': 'Địa điểm (Quốc gia/Khu vực Thành phố,Tỉnh)',
-  'form.headline': 'Tiêu đề',
   'form.aboutMe': 'Giới thiệu',
   'form.schoolName': 'Tên trường/tổ chức',
   'form.levelOfEducation': 'Trình độ học vấn',


### PR DESCRIPTION
## 🔥 PR 제목

fix(UI): 프로필 편집 Figma 정합성 개선 및 headline 제거

## ✨ 작업 내용

- DatePicker 오픈 시 선택된 값이 각 스크롤 컬럼 중앙에 오도록 UX 개선
- FormInput 사이즈/테마 연동 및 프로필 편집 화면 스타일 정합성 보완
- DialcodePicker 및 편집 화면 UI를 Figma 의도에 맞게 보정
- 사용되지 않는 `headline` 필드 제거
  - 프론트 폼/표시 로직
  - 백엔드 validation/use-case 경로
  - Prisma schema/seed/migration 경로
  - 관련 테스트/픽스처
- 관련 이슈: #86

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다. (N/A: 코드/스키마/테스트 중심 변경)
- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.

## 🚀 테스트 방법

- `pnpm test -- __tests__/components/ui/date-picker.test.tsx __tests__/components/ui/form-input.test.tsx __tests__/entities/profile/profile-card.test.tsx __tests__/features/profile-edit/profile-public-form.test.tsx __tests__/lib/validations/profile.test.ts __tests__/app/candidate-profile-page.test.tsx __tests__/app/candidate-slug-page.test.tsx __tests__/app/candidate-profile-edit-page.test.tsx`
- 결과: 8 suites passed, 86 tests passed

## 📸 스크린샷 / 시연 (선택)

N/A

## 🙏 리뷰어에게 한마디

이번 변경은 프로필 편집 UX 정합성과 불필요 데이터(`headline`) 제거를 하나의 브랜치에서 정리한 작업입니다. 스키마 변경이 포함되어 있어 배포 파이프라인의 migration 적용 순서만 확인 부탁드립니다.
